### PR TITLE
[#14] Feat: Link 모든 기능 구현

### DIFF
--- a/config/response.status.js
+++ b/config/response.status.js
@@ -3,6 +3,7 @@ import { StatusCodes } from "http-status-codes";
 export const status = {
     // success
     SUCCESS: {status: StatusCodes.OK, "isSuccess": true, "code": 2000, "message": "success!"},
+    CREATED: {status: StatusCodes.CREATED, "isSuccess": true, "code": 2000, "message": "create success!"},
 
     // error
     // common err
@@ -12,6 +13,12 @@ export const status = {
     METHOD_NOT_ALLOWED: {status: StatusCodes.METHOD_NOT_ALLOWED, "isSuccess": false, "code": "COMMON003", "message": "지원하지 않는 Http Method 입니다." },
     FORBIDDEN: {status: StatusCodes.FORBIDDEN, "isSuccess": false, "code": "COMMON004", "message": "금지된 요청입니다." },
     NOT_FOUND: {status: StatusCodes.NOT_FOUND, "isSuccess": false, "code": "COMMON005", "message": "요청한 페이지를 찾을 수 없습니다. 관리자에게 문의 바랍니다." },
+    
+    // db error
+    PARAMETER_IS_WRONG: {status: StatusCodes.BAD_REQUEST, "isSuccess": false, "code": "DB001", "message": "잘못된 요청 파라미터입니다." },
+    FAILED_TO_UPDATE: {status: StatusCodes.INTERNAL_SERVER_ERROR, "isSuccess": false, "code": "DB002", "message": "DB 데이터 업데이트에 실패했습니다." },
+    FAILED_TO_DELETE: {status: StatusCodes.INTERNAL_SERVER_ERROR, "isSuccess": false, "code": "DB003", "message": "DB 데이터 삭제에 실패했습니다." },
+
 
     // alert error
     ALERT_NOT_FOUND: {status: StatusCodes.NOT_FOUND, "isSuccess": false, "code": "ALERT001", "message": "해당 알림을 찾을 수 없습니다." },

--- a/index.js
+++ b/index.js
@@ -45,6 +45,7 @@ app.use((err, req, res, next) => {
     res.locals.message = err.message;   
     // 개발환경이면 에러를 출력하고 아니면 출력하지 않기
     res.locals.error = process.env.NODE_ENV !== 'production' ? err : {}; 
+
     res.status(err.data.status || status.INTERNAL_SERVER_ERROR).send(response(err.data));
 });
 

--- a/src/controllers/link.controller.js
+++ b/src/controllers/link.controller.js
@@ -26,7 +26,6 @@ export const getSummaryCnt = async (req,res) => {
     try {
         const AIResponse = await generateUrlSummary(url);
         res.send(response(status.SUCCESS, AIResponse ));
-        console.log(`AI 응답: ${AIResponse}`);
     } catch (err) {
         return BaseError(status.BAD_REQUEST);
     }

--- a/src/controllers/link.controller.js
+++ b/src/controllers/link.controller.js
@@ -1,10 +1,22 @@
-import { response } from "../../config/response";
-import { status } from "../../config/response.status";
-import { BaseError } from "../../config/error";
-import { generateUrlSummary } from "../services/link.service";
+import { response } from "@config/response";
+import { status } from "@config/response.status";
+import { BaseError } from "@config/error";
+import { createNewLinkSer, deleteLinkByIdSer, generateUrlSummary, getLinkSer, updateLikeSer, updateVisitSer, updateZipIdSer } from "@services/link.service";
 
 
-export const getSummary = async (req,res) => {
+export const getLinksCnt = async  (req, res) => {
+    const zip_id = req.params.zip_id;
+    const user_id = req.params.user_id; // 추후 토큰에서 가져오는 방법으로 변경
+    const tag = req.query.tag;
+    
+    try {
+        res.send(response(status.SUCCESS, await getLinkSer(zip_id, user_id, tag)));
+    } catch (err) {
+        return BaseError(status.BAD_REQUEST)
+    }
+}
+
+export const getSummaryCnt = async (req,res) => {
     const url = req.body.url;
 
     if (!url) { // 에러 메시지 추후 수정
@@ -15,7 +27,51 @@ export const getSummary = async (req,res) => {
         const AIResponse = await generateUrlSummary(url);
         res.send(response(status.SUCCESS, AIResponse ));
         console.log(`AI 응답: ${AIResponse}`);
-    } catch (error) {
+    } catch (err) {
+        return BaseError(status.BAD_REQUEST);
+    }
+}
+
+export const createNewLinkCnt = async (req, res) => {
+    // text 정보를 받아온 경우 tag: text 로 아니면 link로 저장
+    try {
+        res.send(response(status.CREATED, await createNewLinkSer(req.body)));
+    } catch (err) {
+        return BaseError(status.BAD_REQUEST);
+    }
+}
+
+export const updateVisitCnt = async (req, res) => {
+    // link id 받아와서 visit 정보를 +1 & visit_date에 visit 당시 시간정보를 저장
+    try {
+        res.send(response(status.SUCCESS, await updateVisitSer(req.params.link_id)))
+    } catch (err){
+        return BaseError(status.BAD_REQUEST);
+    }
+}
+
+export const updateLikeCnt = async (req, res) => {
+    try {
+        res.send(response(status.SUCCESS, await updateLikeSer(req.params.link_id)))
+    } catch (err){
+        return BaseError(status.BAD_REQUEST);
+    }
+}
+/** 링크의 Zip 이동 */
+export const updateZipIdCnt = async (req, res) => {
+    try {
+        const {link_id, new_zip_id} = req.params;
+        res.send(response(status.SUCCESS, await updateZipIdSer(link_id, new_zip_id)));
+    } catch (err){
+        return BaseError(status.BAD_REQUEST);
+    }
+}
+
+
+export const deleteLinkByIdCnt = async (req, res) => {
+    try {
+        res.send(response(status.SUCCESS, await deleteLinkByIdSer(req.params.link_id)))
+    } catch (err){
         return BaseError(status.BAD_REQUEST);
     }
 }

--- a/src/dtos/link.dto.js
+++ b/src/dtos/link.dto.js
@@ -1,0 +1,49 @@
+export const createLinkResDto = (link_id) => {
+    return `생성된 링크 id: ${link_id}`;
+}
+
+export const getLinksResDto = (getResult) => {
+    return getResult.map(link=> ({
+        id: link.id,
+        zip_id: link.zip_id,
+        user_id: link.user_id,
+        title: link.title,
+        url: link.url,
+        text: link.text,
+        memo: link.memo,
+        tag: link.tag,
+        alert_date: link.alert_date,
+        thumb: link.thumb,
+        like: link.like,
+        visit: link.visit,
+        visit_date: link.visit_date,
+        created_at: link.created_at,
+        updated_at: link.updated_at,
+    }));
+}
+
+export const updateVisitResDto = (updateResult) => {
+    return {
+        link_id: updateResult.id ,
+        visit: updateResult.visit,
+        visit_date: updateResult.visit_date
+    }
+}
+
+export const updateLikeResDto = (updateResult) => {
+    return {
+        link_id: updateResult.id ,
+        like: updateResult.like
+    }
+}
+
+export const updateZipIdResDto = (updateResult) => {
+    return {
+        link_id: updateResult.id ,
+        new_zip_id: updateResult.zip_id
+    }
+}
+
+export const deleteZipIdResDto = (affectedRows) => {
+    return `${affectedRows}개의 링크 데이터를 성공적으로 삭제하였습니다.`
+}

--- a/src/models/link.dao.js
+++ b/src/models/link.dao.js
@@ -1,0 +1,144 @@
+import { pool } from "@config/db.config";
+import { BaseError } from "@config/error";
+import { status } from "@config/response.status";
+import { deleteLinkByIdSql, insertLinkSql, insertMemoLinkSql, insertMemoTextSql, insertTextSql, selectLinksByTagSql, selectLinksByZipIdSql, selectUpdatedLikeSql, selectUpdatedVisitSql, selectUpdatedZipIdSql, updateLikeSql, updateThumbSql, updateVisitSql, updateZipIdSql } from "./link.sql";
+
+
+/** 링크 호출 DAO - 모든 링크, 링크태그, 텍스트태그 */
+
+/** 링크 생성 DAO, 링크 id리턴 */
+export const addLinkDao = async (data) => {
+    try {
+        const {zip_id, user_id, title, text, url, memo, alert_date} = data;
+        let sql;
+        let values = [zip_id, user_id, title, url, alert_date];
+
+        if(memo != null && text != null){
+            sql = insertMemoTextSql;
+            values.splice(5,0, memo,text,'text');
+        } else if(memo == null && text != null){
+            sql = insertTextSql;
+            values.splice(5,0, text, 'text');
+        } else if(memo != null && text == null) {
+            sql = insertMemoLinkSql;
+            values.splice(5,0, memo);
+        } else if(memo == null && text == null) {
+            sql = insertLinkSql;
+        }
+
+        const conn = await pool.getConnection();
+        const [result] = await conn.query(sql, values) // sql쿼리에 보낼 정보
+        conn.release();
+        return result.insertId; // link_id
+    } catch (err) {
+        console.log(err);
+        throw new BaseError(status.BAD_REQUEST);
+    }
+}
+
+//링크id값 받아서 thumb값 갱신하는 dao
+export const updateThumbDao = async (linkId, thumb) => {
+    try {
+        const conn = await pool.getConnection();
+        const [result] = await conn.query(updateThumbSql, [thumb, linkId]);
+        
+        conn.release();
+        
+        return result.affectedRows;
+    } catch (err){
+        console.log('thumb dao err:',err);
+        throw new BaseError(status.BAD_REQUEST)
+    }
+}
+
+export const getLinksDao = async (zipId, userId, tag) => {
+    let sql;
+    let values = [zipId, userId, tag]; 
+    try{
+        if (tag == 'link' || tag == 'text'){
+            sql = selectLinksByTagSql;
+        } else {
+            sql = selectLinksByZipIdSql;
+            values.splice(2,1); // zipId, userId만 전달
+        }
+        const conn = await pool.getConnection();
+        const [result] = await conn.query(sql, values);
+
+        conn.release();
+
+        return result;
+    } catch (err) {
+        console.log(err);
+        throw new BaseError(status.BAD_REQUEST);
+    }
+}
+
+export const updateVisitDao = async (linkId) => {
+    try{
+        const conn = await pool.getConnection();
+        const [updateResult] = await conn.query(updateVisitSql, [linkId]);
+        const [selectResult] = await conn.query(selectUpdatedVisitSql, [linkId]);
+
+        conn.release();
+        
+        if (updateResult.affectedRows === 1) {
+            return selectResult[0];
+        } else {
+            throw new BaseError(status.NOT_FOUND);
+        }
+    } catch (err) {
+        throw new BaseError(status.BAD_REQUEST);
+    }
+}
+
+export const updateLikeDao = async (linkId) => {
+    try{
+        const conn = await pool.getConnection();
+        const [updateResult] = await conn.query(updateLikeSql, [linkId]);
+        const [selectResult] = await conn.query(selectUpdatedLikeSql, [linkId]);
+
+        conn.release();
+        if (updateResult.affectedRows === 1) {
+            return selectResult[0];
+        } else {
+            throw new BaseError(status.NOT_FOUND);
+        }
+    } catch (err) {
+        throw new BaseError(status.BAD_REQUEST);
+    }
+}
+
+export const updateZipIdDao = async (linkId, newZipId) => {
+    try{
+        const conn = await pool.getConnection();
+        const [updateResult] = await conn.query(updateZipIdSql, [newZipId, linkId]);
+        const [selectResult] = await conn.query(selectUpdatedZipIdSql, [linkId]);
+
+        conn.release();
+
+        if (updateResult.affectedRows === 1) {
+            return selectResult[0];
+        } else {
+            throw new BaseError(status.NOT_FOUND);
+        }
+    } catch (err) {
+        throw new BaseError(status.BAD_REQUEST);
+    }
+}
+
+export const deleteZipIdDao = async (linkId) => {
+    try{
+        const conn = await pool.getConnection();
+        const [result] = await conn.query(deleteLinkByIdSql, [linkId]);
+
+        conn.release();
+
+        if (result.affectedRows === 0) {
+            throw new BaseError(status.NOT_FOUND);
+        } else {
+            return result.affectedRows;
+        }
+    } catch (err) {
+        throw new BaseError(status.BAD_REQUEST);
+    }
+}

--- a/src/models/link.sql.js
+++ b/src/models/link.sql.js
@@ -1,0 +1,35 @@
+/** CREATE LINK */
+// text정보가 있어서 text태그로 생성
+export const insertMemoTextSql = "INSERT INTO link (zip_id, user_id, title, url, alert_date, memo, text, tag, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, NOW(), NOW());";
+
+export const insertTextSql = "INSERT INTO link (zip_id, user_id, title, url, alert_date, text, tag, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, NOW(), NOW());";
+
+// text 가 없어서 link로 기본생성
+export const insertMemoLinkSql = "INSERT INTO link (zip_id, user_id, title, url, memo, alert_date, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, NOW(), NOW());"
+
+export const insertLinkSql = "INSERT INTO link (zip_id, user_id, title, url, alert_date, created_at, updated_at) VALUES (?, ?, ?, ?, ?, NOW(), NOW());"
+
+// id로 찾은 link에 thumb값 넣기
+export const updateThumbSql = "UPDATE link SET thumb = ? WHERE id = ?"
+
+/** GET LINKS */
+export const selectLinksByZipIdSql = "SELECT * FROM link WHERE zip_id = ? AND user_id = ?";
+
+export const selectLinksByTagSql = "SELECT * FROM link WHERE zip_id = ? AND user_id = ? AND tag = ?";
+
+/** UPDATE VISIT */
+export const updateVisitSql = "UPDATE link SET visit = visit + 1, visit_date = NOW() WHERE id = ?";
+
+export const selectUpdatedVisitSql = "SELECT id, visit, visit_date FROM link WHERE id = ?";
+
+/** UPDATE LIKE */
+export const updateLikeSql = "UPDATE link SET `like` = CASE WHEN `like` = 0 THEN 1 ELSE 0 END WHERE id = ?";
+
+export const selectUpdatedLikeSql = "SELECT id, `like` FROM link WHERE id = ?";
+
+/** UPDATE ZIP ID */
+export const updateZipIdSql = "UPDATE link SET zip_id = ? WHERE id = ?";
+export const selectUpdatedZipIdSql = "SELECT id, zip_id FROM link WHERE id = ?"
+
+/** DELETE LINK BY ID */
+export const deleteLinkByIdSql = "DELETE FROM link WHERE id = ?";

--- a/src/providers/link.provider.js
+++ b/src/providers/link.provider.js
@@ -1,3 +1,5 @@
+import { BaseError } from "@config/error";
+import { status } from "@config/response.status";
 import axios from "axios";
 import cheerio from "cheerio";
 import OpenAI from "openai";
@@ -38,4 +40,22 @@ export const getGptResponse = async (summary) => {
     });
 
     return completion.choices[0].message.content;
+}
+
+export const getUrlThumb = async (url) => {
+    if(!url){
+        return null;
+    }
+
+    try {
+        const { data } = await axios.get(url);
+        const $ = cheerio.load(data);
+        const ogImage = $('meta[property="og:image"]').attr('content');
+
+        console.log('thumb 추출 내용:', ogImage);
+        return ogImage || null; //og:image가 없는 경우 null반환
+    } catch (err) {
+        console.log(err);
+        return null; //url이 실제로 접속 불가능한 url이어도 에러 처리하지 않도록
+    }
 }

--- a/src/providers/link.provider.js
+++ b/src/providers/link.provider.js
@@ -28,8 +28,6 @@ export const fetchUrlContent = async (url) => {
 }
 /** 요약 정보를 통해 gpt로 사이트 추측 */
 export const getGptResponse = async (summary) => {
-    console.log('summary:', summary);
-
     const completion = await openai.chat.completions.create({
         model: "gpt-3.5-turbo",
         messages: [
@@ -37,6 +35,43 @@ export const getGptResponse = async (summary) => {
             { role: "user", content: `다음은 사용자가 입력한 url의 메타 정보 및 텍스트 정보를 추출한 정보입니다. 이 정보를 보고 사용자가 입력한 url이 어떤 링크인지 정리해서 설명해주세요: ${summary}` }
         ],
         max_tokens: 300
+    });
+
+    return completion.choices[0].message.content;
+}
+//응답 형태, summary, videoTitle, videoAuthor
+export const getYoutubeSummary = async (url) => {
+    const options = {
+        method: 'GET',
+        url: 'https://youtube-video-summarizer1.p.rapidapi.com/v1/youtube/summarizeVideoFromCache',
+        params: {
+            videoURL: url
+        },
+        headers: {
+            'x-rapidapi-key': process.env.RAPIDAPI_KEY,
+            'x-rapidapi-host': process.env.RAPIDAPI_HOST,
+        }
+    };
+    try{
+        const response = await axios.request(options);
+        
+        return response.data;
+    } catch (err){
+        console.log('getYoutubeSummary error: ',err);
+        throw err;
+    }
+}
+
+export const getGptYoutubeSummary = async (youtubeSummary) => {
+    const {summary, videoTitle, videoAuthor } = youtubeSummary;
+    const completion = await openai.chat.completions.create({
+        model: "gpt-3.5-turbo",
+        messages: [
+            { role: "system", content: "Your role is to summarize youtube video content" },
+            { role: "user", content: `다음은 사용자가 입력한 유튜브 url의 요약 내용입니다. 제목, 채널명, 비디오 내용 요약 등을 읽고 어떤 내용을 다루는 동영상인지 간략하게 정리해주세요.
+                제목: ${videoTitle}, 채널명: ${videoAuthor}, 동영상 내용:${summary}` }
+        ],
+        max_tokens: 1000
     });
 
     return completion.choices[0].message.content;

--- a/src/routes/link.route.js
+++ b/src/routes/link.route.js
@@ -1,10 +1,27 @@
 // src/routes/list.route.js
 import express from 'express';
 import asyncHandler from 'express-async-handler';
-import { getSummary } from '../controllers/link.controller';
+import { getLinksCnt, createNewLinkCnt, getSummaryCnt, updateVisitCnt, updateLikeCnt, updateZipIdCnt, deleteLinkByIdCnt } from '@controllers/link.controller';
 //controller
 
 export const linkRouter = express.Router();
 
-// 텍스트 요약(url전송)
-linkRouter.post('/summary', asyncHandler(getSummary));
+
+/** GET API */
+// user_id는 token에서 받아오는걸로 수정할 예정
+linkRouter.get("/get_links/:zip_id/:user_id", asyncHandler(getLinksCnt));
+
+
+
+/** POST API */
+linkRouter.post('/summary', asyncHandler(getSummaryCnt)); // 텍스트 요약(url전송)
+linkRouter.post('/add', asyncHandler(createNewLinkCnt)); 
+
+
+/** PATCH API */
+linkRouter.patch('/visit/:link_id', asyncHandler(updateVisitCnt));
+linkRouter.patch('/update_like/:link_id', asyncHandler(updateLikeCnt));
+linkRouter.patch('/move/:link_id/:new_zip_id', asyncHandler(updateZipIdCnt));
+
+/** DELETE API */
+linkRouter.delete('/delete/:link_id', asyncHandler(deleteLinkByIdCnt));

--- a/src/services/link.service.js
+++ b/src/services/link.service.js
@@ -1,10 +1,11 @@
-import { fetchUrlContent, getUrlThumb } from "@providers/link.provider";
-import { getGptResponse } from "@providers/link.provider";
+import { fetchUrlContent, getUrlThumb, getYoutubeSummary } from "@providers/link.provider";
+import { getGptResponse, getGptYoutubeSummary } from "@providers/link.provider";
 import { BaseError} from "@config/error";
 import { status } from "@config/response.status";
 import { addLinkDao, deleteZipIdDao, getLinksDao, updateLikeDao, updateThumbDao, updateVisitDao, updateZipIdDao } from "@models/link.dao";
 import { createLinkResDto, deleteZipIdResDto, getLinksResDto, updateLikeResDto, updateVisitResDto, updateZipIdResDto } from "@dtos/link.dto";
 
+/** 사이트 정보 요약 */
 export const summarizeContent = async (content, maxLength = 1000) => {
     if(!content || content.trim().length === 0) {
         return "페이지에서 유효한 정보를 찾을 수 없습니다."
@@ -15,16 +16,29 @@ export const summarizeContent = async (content, maxLength = 1000) => {
     }
     return content;
 }
+
+export const checkYoutube = (url) => {
+    if (url.includes('youtube.com/watch?v=') || url.includes('youtu.be/'))
+        return true;
+}
+
 /** url 요약 정보 생성 */
 export const generateUrlSummary = async (url) =>  {
-    const content = await fetchUrlContent(url);
-    if (!content) {
-        throw new BaseError(status.NOT_FOUND);    
+    const isYoutube = checkYoutube(url);
+    if(!isYoutube){
+        const content = await fetchUrlContent(url);
+        if (!content) {
+            throw new BaseError(status.NOT_FOUND);    
+        }
+        const summary = await summarizeContent(content.content, 300);
+        const response = await getGptResponse(summary);
+        return response;
+    } else { // 유튜브 URL인 경우
+        const youtubeSummary = await getYoutubeSummary(url);
+        const gptResponse = await getGptYoutubeSummary(youtubeSummary);
+        const formattedText = `요약을 요청하신 URL이 유튜브 플랫폼 동영상으로 확인되어 영상 내용을 AI로 요약한 결과입니다 : ${gptResponse}`
+        return formattedText;
     }
-
-    const summary = await summarizeContent(content.content, 300);
-    const response = await getGptResponse(summary);
-    return response;
 }
 
 export const getLinkSer = async (zipId, userId, tag) => {

--- a/src/services/link.service.js
+++ b/src/services/link.service.js
@@ -1,7 +1,9 @@
-import { fetchUrlContent } from "../providers/link.provider";
-import { getGptResponse } from "../providers/link.provider";
-import { BaseError} from "../../config/error";
-import { status } from "../../config/response.status";
+import { fetchUrlContent, getUrlThumb } from "@providers/link.provider";
+import { getGptResponse } from "@providers/link.provider";
+import { BaseError} from "@config/error";
+import { status } from "@config/response.status";
+import { addLinkDao, deleteZipIdDao, getLinksDao, updateLikeDao, updateThumbDao, updateVisitDao, updateZipIdDao } from "@models/link.dao";
+import { createLinkResDto, deleteZipIdResDto, getLinksResDto, updateLikeResDto, updateVisitResDto, updateZipIdResDto } from "@dtos/link.dto";
 
 export const summarizeContent = async (content, maxLength = 1000) => {
     if(!content || content.trim().length === 0) {
@@ -23,4 +25,74 @@ export const generateUrlSummary = async (url) =>  {
     const summary = await summarizeContent(content.content, 300);
     const response = await getGptResponse(summary);
     return response;
+}
+
+export const getLinkSer = async (zipId, userId, tag) => {
+    const getResult = await getLinksDao(zipId, userId, tag);
+    
+    if(getResult == null) {
+        return '해당되는 문자열이 없습니다.';
+    } else {
+        return getLinksResDto(getResult);
+    }
+}
+
+export const createNewLinkSer = async (body) => {
+    const createdLinkId = await addLinkDao(body); 
+
+    // provider를 통해 body.url의 thumb 주소값 가져옴
+    const thumb = await getUrlThumb(body.url);
+    
+    
+    if(thumb != null) {
+        const affectedRows = await updateThumbDao(createdLinkId, thumb);
+
+        if (affectedRows === 0) {
+            throw new BaseError(status.FAILED_TO_UPDATE);
+        }
+    }
+
+    if(createdLinkId == -1) {
+        throw new BaseError(status.PARAMETER_IS_WRONG);
+    } else {
+        return createLinkResDto(createdLinkId);
+    }
+}
+
+export const updateVisitSer = async (linkId) => {
+    const updateVisitResult = await updateVisitDao(linkId); 
+
+    if(updateVisitResult == null){
+        throw new BaseError(status.FAILED_TO_UPDATE);
+    } else {
+        return updateVisitResDto(updateVisitResult);
+    }
+}
+
+export const updateLikeSer = async (linkId) => {
+    const updateLikeResult = await updateLikeDao(linkId);
+    if(updateLikeResult == null){
+        throw new BaseError(status.FAILED_TO_UPDATE);
+    } else {
+        return updateLikeResDto(updateLikeResult);
+    }
+}
+
+export const updateZipIdSer = async (linkId, newZipId) => {
+    const updateZipIdResult = await updateZipIdDao(linkId, newZipId);
+    if(updateZipIdResult == null){
+        throw new BaseError(status.FAILED_TO_UPDATE);
+    } else {
+        return updateZipIdResDto(updateZipIdResult);
+    }
+}
+
+export const deleteLinkByIdSer = async (linkId) => {
+    const affectedRows = await deleteZipIdDao(linkId);
+    
+    if(affectedRows == null){
+        throw new BaseError(status.FAILED_TO_DELETE);
+    } else {
+        return deleteZipIdResDto(affectedRows);
+    }
 }

--- a/swagger/link.swagger.yml
+++ b/swagger/link.swagger.yml
@@ -1,0 +1,391 @@
+paths:
+  /link/get_links/{zip_id}/{user_id}:
+    get:
+      tags:
+        - Link
+      summary: 링크 데이터 가져오기
+      description: |
+          만약 조건(zip, user의 ID값)에 해당하는 값이 없더라도 오류 처리 하지 않고 빈 배열을 반환합니다.
+          응답 데이터 중 thumb값은 해당 사이트에서 따로 설정해둔 이미지가 없을 경우 null로 설정됩니다. 
+      parameters:
+        - name: zip_id
+          in: path
+          description: '링크가 속한 zip의 id값을 파라미터로 넘겨야 합니다.'
+          required: true
+          type: integer
+          format: int32
+          example: 1
+        - name: user_id
+          in: path
+          description: '사용자의 id값을 파라미터로 넘겨야 합니다.'
+          required: true
+          type: integer
+          format: int32
+          example: 123
+        - name: tag
+          in: query
+          description: 'tag값이 link인 경우 link인 값들만 호출, text인 경우 text인 값들만 호출, 설정하지 않은 경우 모든 링크 데이터를 호출'
+          required: false
+          type: string
+          example: 'link'
+      responses:
+        200:
+          description: 링크 데이터가 성공적으로 호출된 경우
+          schema:
+            type: array
+            items:
+              type: object
+              properties:
+                id:
+                  type: integer
+                zip_id:
+                  type: integer
+                user_id:
+                  type: integer
+                title:
+                  type: string
+                url:
+                  type: string
+                text:
+                  type: string
+                memo:
+                  type: string
+                tag:
+                  type: string
+                alert_date:
+                  type: string
+                  format: date-time
+                thumb:
+                  type: string
+                like:
+                  type: integer
+                visit:
+                  type: integer
+                visit_date:
+                  type: string
+                  format: date-time
+                created_at:
+                  type: string
+                  format: date-time
+                updated_at:
+                  type: string
+                  format: date-time
+        400:
+          description: 잘못된 요청
+          schema:
+            type: object
+            properties:
+              status:
+                type: integer
+                example: 400
+              isSuccess:
+                type: boolean
+                example: false
+              code:
+                type: integer
+                example: COMMON001
+              message:
+                type: string
+                example: "잘못된 요청입니다"
+        500:
+          description: 서버 에러
+          schema:
+            type: object
+            properties:
+              status:
+                type: integer
+                example: 500
+              isSuccess:
+                type: boolean
+                example: false
+              code:
+                type: integer
+                example: COMMON000
+              message:
+                type: string
+                example: "서버 에러, 관리자에게 문의 바랍니다."
+
+  /link/summary:
+    post:
+      tags:
+        - Link
+      summary: url의 정보 추출 및 AI 요약
+      consumes:
+        - application/json
+      parameters:
+        - in: body
+          name: body
+          description: url 정보를 AI에게 요약받기 위한 요청 양식
+          required: true
+          schema:
+            type: object
+            properties:
+              url:
+                type: string
+                example: https://www.example.com
+
+      responses:
+        200:
+          description: AI의 응답을 성공적으로 받아왔습니다.
+          schema:
+            type: object
+            properties:
+              isSuccess:
+                type: boolean
+                example: true
+              code:
+                type: integer
+                example: 2000
+              message:
+                type: string
+                example: "success!"
+              result:
+                type: object
+                properties:
+                  summary:
+                    type: string
+                    example: "This is a summary of the content at the given URL."
+        400:
+          description: 잘못된 요청
+          schema:
+            type: object
+            properties:
+              status:
+                type: integer
+                example: 400
+              isSuccess:
+                type: boolean
+                example: false
+              code:
+                type: integer
+                example: COMMON001
+              message:
+                type: string
+                example: 잘못된 요청입니다
+        500:
+          description: 서버 에러
+          schema:
+            type: object
+            properties:
+              status:
+                type: integer
+                example: 500
+              isSuccess:
+                type: boolean
+                example: false
+              code:
+                type: integer
+                example: COMMON000
+              message:
+                type: string
+                example: 서버 에러, 관리자에게 문의 바랍니다.
+  
+  /link/add:
+    post:
+      tags:
+        - Link
+      summary: link 데이터(text포함) 추가 생성
+      consumes:
+        - application/json
+      parameters:
+        - in: body
+          name: body
+          description: 링크를 생성하기 위한 데이터
+          required: true
+          schema:
+            type: object
+            properties:
+              zip_id:
+                type: integer
+                example: 99
+              user_id:
+                type: integer
+                example: 99
+              title:
+                type: string
+                example: "Link Title"
+              text:
+                type: string
+                example: "This is some text"
+              url:
+                type: string
+                example: "https://www.example.com"
+              memo:
+                type: string
+                example: "This is a memo"
+              alert_date:
+                type: string
+                format: date-time
+                example: "2023-01-01T12:00:00Z"
+      responses:
+        201:
+          description: 링크가 성공적으로 생성된 경우
+          schema:
+            type: object
+            properties:
+              isSuccess:
+                type: boolean
+                example: true
+              code:
+                type: integer
+                example: 2000
+              message:
+                type: string
+                example: "create success!"
+              result:
+                type: string
+                example: "생성된 링크 id: 123"
+        400:
+          description: 잘못된 요청
+          schema:
+            type: object
+            properties:
+              status:
+                type: integer
+                example: 400
+              isSuccess:
+                type: boolean
+                example: false
+              code:
+                type: integer
+                example: COMMON001
+              message:
+                type: string
+                example: "잘못된 요청입니다"
+        500:
+          description: 서버 에러
+          schema:
+            type: object
+            properties:
+              status:
+                type: integer
+                example: 500
+              isSuccess:
+                type: boolean
+                example: false
+              code:
+                type: integer
+                example: COMMON000
+              message:
+                type: string
+                example: "서버 에러, 관리자에게 문의 바랍니다."
+  /link/visit/{link_id}:
+    patch:
+      tags:
+        - Link
+      summary: 링크 방문 수 및 방문 날짜 업데이트
+      parameters:
+        - name: link_id
+          in: path
+          description: '방문 수를 업데이트할 링크의 ID'
+          required: true
+          type: integer
+          format: int32
+          example: 1
+      responses:
+        200:
+          description: 방문 수 및 방문 날짜가 성공적으로 업데이트된 경우
+          schema:
+            type: object
+            properties:
+              link_id:
+                type: integer
+              visit:
+                type: integer
+              visit_date:
+                type: string
+                format: date-time
+        400:
+          description: 잘못된 요청
+        500:
+          description: 서버 에러
+
+  /link/update_like/{link_id}:
+    patch:
+      tags:
+        - Link
+      summary: 링크 좋아요 상태 업데이트
+      parameters:
+        - name: link_id
+          in: path
+          description: '좋아요 상태를 업데이트할 링크의 ID'
+          required: true
+          type: integer
+          format: int32
+          example: 1
+      responses:
+        200:
+          description: 좋아요 상태가 성공적으로 업데이트된 경우
+          schema:
+            type: object
+            properties:
+              link_id:
+                type: integer
+              like:
+                type: integer
+        400:
+          description: 잘못된 요청
+        500:
+          description: 서버 에러
+
+  /link/move/{link_id}/{new_zip_id}:
+    patch:
+      tags:
+        - Link
+      summary: 링크의 Zip 이동
+      parameters:
+        - name: link_id
+          in: path
+          description: 'Zip을 이동할 링크의 ID'
+          required: true
+          type: integer
+          format: int32
+          example: 1
+        - name: new_zip_id
+          in: path
+          description: '이동할 Zip의 ID'
+          required: true
+          type: integer
+          format: int32
+          example: 2
+      responses:
+        200:
+          description: Zip이 성공적으로 업데이트된 경우
+          schema:
+            type: object
+            properties:
+              link_id:
+                type: integer
+              new_zip_id:
+                type: integer
+        400:
+          description: 잘못된 요청
+        500:
+          description: 서버 에러
+
+  /link/delete/{link_id}:
+    delete:
+      tags:
+        - Link
+      summary: 링크 삭제
+      parameters:
+        - name: link_id
+          in: path
+          description: '삭제할 링크의 ID'
+          required: true
+          type: integer
+          format: int32
+          example: 1
+      responses:
+        200:
+          description: 링크가 성공적으로 삭제된 경우
+          schema:
+            type: string
+            example: "1개의 링크 데이터를 성공적으로 삭제하였습니다."
+        400:
+          description: 잘못된 요청
+        500:
+          description: 서버 에러
+
+
+        


### PR DESCRIPTION
## 관련 이슈

- #14 

## 요약 📝

모든 링크 기능 구현 완료하였습니다.

- 링크 데이터 조회
- 링크 생성
- 링크 삭제
- 링크 좋아요/좋아요 해제
- 링크 방문 및 최근 방문일 기록
- 링크 zip 이동
- swagger 문서 작성

## 상세 내용 🔥

- 링크 데이터 조회의 경우 경로에 파라미터 값을 통해 생성할 zip의 id를 입력받는 방식으로 구현하였습니다. 유저 id의 경우 아직 로그인 기능과 연동되지 않아 토큰에서 받아오는 방식이 구현되지 않았기 때문에 마찬가지로 파라미터에서 받아오는 방식으로 구현해두었고, 로그인 기능과 연동되는 대로 수정하도록 하겠습니다.
- 링크 생성은 총 4가지 sql문이 사용되었습니다. 사용자가 생성하고자 하는 링크가 텍스트 요약을 받은 정보인지 아닌지, 그리고 메모 데이터가 있는지 없는지에 따라 4가지 경우의 수를 모두 하나의 라우터로 처리하도록 구현하였습니다.
- 링크 삭제는 파라미터 값으로 링크의 ID 값을 입력받고, 입력받은 ID에 해당하는 링크 데이터를 지우도록 구현하였습니다. 응답 데이터에는 삭제된 row의 데이터를 남기기 까다로워 삭제된 행의 수를 입력하도록 응답 형식을 정했습니다. 
- 링크 좋아요 기능은 0은 좋아요를 누르지 않은 링크, 1은 좋아요를 누른 링크로 구현하였습니다. 사용자에게 링크의 ID값을 입력받고, 입력받은 ID에 해당하는 링크 데이터의 like필드 값을 체크하여 0이면 1로, 1이면 0으로 변하도록 하여 on/off기능처럼 구현하였습니다.
- 방문 기능은 사용자가 링크를 방문할 때 해당 경로로 patch 요청을 보내는 방식으로 생각하고 설계하였습니다. 해당 경로로 요청이 오면 visit 값을 체크하여 기존 visit 값에 +1을 하고, 최근 방문일을 현재 시각으로 갱신하도록 하였습니다.
- zip이동은 params로 두개의 값을 받습니다. 이동할 링크의 id와 이동하고자 하는 zip의 id입니다. 기존에 어떤 zip에 속해있었는지에 대한 데이터는 기획서나 디자인 화면을 보았을 때 필요 없는 데이터로 판단되어, 응답 데이터 또한 이동한 링크와 바뀐 zip id만 응답으로 보내도록 하였습니다.
- 지난 AI 요약기능 구현 때 작성하지 않았던 부분까지 포함하여 swagger 문서 또한 작성 완료하였습니다. 

## 리뷰어에게 부탁, 유의사항 🙏

- 상세 내용에 적혀있듯 아직 로그인 기능과의 연동이 되지 않아, 링크 데이터 호출, 생성 등에 사용되는 user의 ID값은 수동으로 입력하도록 구현하였습니다. 추후 로그인 기능과 연동하고 토큰에서 추출하여 자동으로 사용하도록 수정하겠습니다.
