### PR TITLE
[#23] Feat: 최근저장/좋아요 리스트 구현

### DIFF
--- a/src/controllers/list.controller.js
+++ b/src/controllers/list.controller.js
@@ -2,9 +2,17 @@
 import { response } from "@config/response.js";
 import { status } from "@config/response.status.js";
 
-import { getUnviewList } from "../providers/list.provider.js";
+import { getUnviewList, getLikeList, getRecentList } from "../providers/list.provider.js";
 
 export const viewUnviewList = async (req,res,next) => {//미열람 링크 리스트 조회
     console.log("미열람 링크 리스트를 출력합니다. ");
     res.send(response(status.SUCCESS, await getUnviewList(req.params, req.query)));
+}
+
+export const viewLikeList = async(req,res)=>{
+    res.send(response(status.SUCCESS, await getLikeList(req.params, req.query)))
+}
+
+export const viewRecentList = async(req,res)=>{
+    res.send(response(status.SUCCESS, await getRecentList(req.params, req.query)))
 }

--- a/src/dtos/list.dto.js
+++ b/src/dtos/list.dto.js
@@ -25,15 +25,39 @@ export const unviewListResponseDTO = (links) => {
       return { "links": unviewlists };
 }
 
+export const ListResponseDTO = (links) => {
+  // 링크가 없을 경우 빈 배열 반환
+  if (!links || links.length === 0) {
+      return { "links": [] };
+  }
+
+  const Linklists = links.map((link) => ({
+      "id": link.id,
+      "title": link.title,
+      "url": link.url,
+      "tag": link.tag,
+      "thumbnail": link.thumb,
+      "like": link.like,
+      "createdAt": formatDate(link.created_at),
+      "zip": {
+        "id": link.zip.id,
+        "title": link.zip.title,
+        "color": link.zip.color,
+      },
+    }));
+  
+    return { "links": Linklists};
+}
+
 
 const formatDate = (date) => {
-    // 날짜 값이 올바른 형식인지 확인
-    const validDate = new Date(date);
-    if (isNaN(validDate.getTime())) {
-        // 날짜 값이 유효하지 않은 경우 에러 처리
-        throw new Error('Invalid date format');
-    }
+  // 날짜 값이 올바른 형식인지 확인
+  const validDate = new Date(date);
+  if (isNaN(validDate.getTime())) {
+      // 날짜 값이 유효하지 않은 경우 에러 처리
+      throw new Error('Invalid date format');
+  }
 
-    // 날짜 값이 유효한 경우 포맷팅
-    return new Intl.DateTimeFormat('kr').format(validDate).replaceAll(" ", "").slice(0, -1);
+  // 날짜 값이 유효한 경우 포맷팅
+  return new Intl.DateTimeFormat('kr').format(validDate).replaceAll(" ", "").slice(0, -1);
 }

--- a/src/models/list.dao.js
+++ b/src/models/list.dao.js
@@ -3,7 +3,7 @@
 import { pool } from "@config/db.config.js";
 import { BaseError } from "@config/error.js";
 import { status } from "@config/response.status.js";
-import { getUnviewListByUserId, getZipById } from "./list.sql.js";
+import { getUnviewListByUserId, getZipById, getLikeListByUserId, getRecentListByUserId } from "./list.sql.js";
 
 //Zip의 정보를 가져오는 함수
 export const getZip = async (zipId) => {
@@ -46,6 +46,98 @@ export const getPreviewUnviewList = async (userId, sort, filter) => {
             }
         }
         else query += " ORDER BY created_at DESC"; //쿼리가 없으면 기본값, 최신순으로 
+        const [links] = await pool.query(query, parseInt(userId));
+        
+        // links에 대해 zip 정보 추가
+        const linksWithZip = await Promise.all(links.map(async (link) => {
+            const zip = await getZip(link.zip_id);
+            return { ...link, zip };
+        }));
+        
+        conn.release();
+        return linksWithZip;
+    
+    } catch (err) {
+        throw new BaseError(status.BAD_REQUEST);
+    }
+}
+
+//좋아요 링크를 조회하는 함수
+export const getPreviewLikeList = async(userId, sort, filter)=>{
+    try {
+        const conn = await pool.getConnection();
+        let query = getLikeListByUserId;
+        
+        // 필터 조건 추가
+        if (filter) {
+            if (filter === "onlylink") {//link만
+                query += " AND tag = 'link' ";
+            } else if (filter === "onlytext") {//text만
+                query += " AND tag = 'text' ";
+            }
+        }
+        
+        // 정렬 조건 추가
+        if (sort) {
+            if (sort === "recent") {//최신순
+                query += " ORDER BY created_at DESC";
+            } else if (sort === "past") {//과거순
+                query += " ORDER BY created_at ASC";
+            } else if (sort === "dictionary") {//사전순
+                query += " ORDER BY title ASC, created_at DESC";
+            } else if (sort === "visit") {//방문순
+                query += " ORDER BY visit DESC, created_at DESC";
+            }
+        }
+        else query += " ORDER BY created_at DESC"; //쿼리가 없으면 기본값, 최신순으로 
+
+        const [links] = await pool.query(query, parseInt(userId));
+
+
+        // links에 대해 zip 정보 추가
+        const linksWithZip = await Promise.all(links.map(async (link) => {
+            const zip = await getZip(link.zip_id);
+            return { ...link, zip };
+        }));
+        
+        conn.release();
+        return linksWithZip;
+    
+    } catch (err) {
+        throw new BaseError(status.BAD_REQUEST);
+    }
+}
+
+//최근 저장 링크를 조회하는 함수 
+export const getPreviewRecentList = async(userId, sort, filter)=>{
+    try {
+        const conn = await pool.getConnection();
+
+        let query = getRecentListByUserId;
+        
+        // 필터 조건 추가
+        if (filter) {
+            if (filter === "onlylink") {//link만
+                query += " AND tag = 'link' ";
+            } else if (filter === "onlytext") {//text만
+                query += " AND tag = 'text' ";
+            }
+        }
+        
+        // 정렬 조건 추가
+        if (sort) {
+            if (sort === "recent") {//최신순
+                query += " ORDER BY created_at DESC";
+            } else if (sort === "past") {//과거순
+                query += " ORDER BY created_at ASC";
+            } else if (sort === "dictionary") {//사전순
+                query += " ORDER BY title ASC, created_at DESC";
+            } else if (sort === "visit") {//방문순
+                query += " ORDER BY visit DESC, created_at DESC";
+            }
+        }
+        else query += " ORDER BY created_at DESC"; //쿼리가 없으면 기본값, 최신순으로 
+
         const [links] = await pool.query(query, parseInt(userId));
         
         // links에 대해 zip 정보 추가

--- a/src/models/list.sql.js
+++ b/src/models/list.sql.js
@@ -2,3 +2,9 @@
 export const getUnviewListByUserId = "SELECT * FROM link WHERE user_id = ? AND visit = 0";
 
 export const getZipById = "SELECT * FROM zip z WHERE z.id = ?";
+
+//좋아요 리스트
+export const getLikeListByUserId = "SELECT * FROM link WHERE user_id = ? AND link.like = 1";
+//최근저장
+export const getRecentListByUserId = "SELECT * FROM link WHERE user_id = ? AND created_at >= DATE_SUB(NOW(), INTERVAL 3 DAY)";
+

--- a/src/providers/list.provider.js
+++ b/src/providers/list.provider.js
@@ -1,6 +1,6 @@
 
-import { unviewListResponseDTO } from "@dtos/list.dto.js";
-import { getPreviewUnviewList } from "@models/list.dao.js";
+import { unviewListResponseDTO, ListResponseDTO } from "@dtos/list.dto.js";
+import { getPreviewUnviewList, getPreviewLikeList, getPreviewRecentList } from "@models/list.dao.js";
 
 export const getUnviewList = async (req, query) => {
     const userId = req.userId;
@@ -15,3 +15,32 @@ export const getUnviewList = async (req, query) => {
     }
     return unviewListResponseDTO(await getPreviewUnviewList(userId , sort, filter));
 }
+
+export const getLikeList = async (req, query) => {
+    const userId = req.userId;
+    let filter, sort;
+    if( query === "undefined" || query === undefined || query === null){
+        filter = null;
+        sort = null;
+    }
+    else{
+        filter=query.filter;
+        sort=query.sort;
+    }
+    return ListResponseDTO(await getPreviewLikeList(userId , sort, filter));
+}
+
+export const getRecentList = async (req, query) => {
+    const userId = req.userId;
+    let filter, sort;
+    if( query === "undefined" || query === undefined || query === null){
+        filter = null;
+        sort = null;
+    }
+    else{
+        filter=query.filter;
+        sort=query.sort;
+    }
+    return ListResponseDTO(await getPreviewRecentList(userId , sort, filter));
+}
+

--- a/src/routes/list.route.js
+++ b/src/routes/list.route.js
@@ -1,9 +1,13 @@
 // src/routes/list.route.js
 import express from "express";
 import asyncHandler from "express-async-handler";
-import { viewUnviewList } from "../controllers/list.controller.js";
+import { viewUnviewList, viewLikeList, viewRecentList } from "../controllers/list.controller.js";
 
 export const listRouter = express.Router();
 
 // 미열람 링크 조회
 listRouter.get('/unview/:userId', asyncHandler(viewUnviewList));
+// 좋아요 링크 조회
+listRouter.get('/like/:userId', asyncHandler(viewLikeList));
+// 최신저장 링크 조회
+listRouter.get('/recent/:userId', asyncHandler(viewRecentList));

--- a/swagger/likelist.swagger.yml
+++ b/swagger/likelist.swagger.yml
@@ -1,0 +1,112 @@
+paths:
+  /list/like/{userId}:
+    get:
+      tags:
+        - List
+      summary: 사용자의 좋아요 링크 조회
+      parameters:
+        - in: path
+          name: userId
+          required: true
+          type: integer
+          description: 사용자 Id
+        - in: query
+          name: sort
+          type: string
+          enum: [recent, past, dictionary, visit]
+          description: 정렬 옵션
+        - in: query
+          name: filter
+          type: string
+          enum: [onlylink, onlytext]
+          description: 필터 옵션
+      responses:
+        "200":
+          description: 좋아요 링크 조회 성공
+          schema:
+            type: object
+            properties:
+              status:
+                type: integer
+                example: 200
+              isSuccess:
+                type: boolean
+                example: true
+              code:
+                type: integer
+                example: 2000
+              message:
+                type: string
+                example: "success!"
+          data:
+            type: object
+            example:
+              {
+                "links":
+                  [
+                    {
+                      "id": "1",
+                      "title": "Link 1",
+                      "url": "https://www.exaple.com/link1",
+                      "tag": "text",
+                      "thumbnail": "https://www.example.com/link1-thumbnail.jpg",
+                      "like": 1,
+                      "createdAt": "2024-07-15",
+                      "zip":
+                        {
+                          "id": "1",
+                          "title": "Zip 1",
+                          "color": "blue"
+                        },
+                    },
+                    {
+                      "id": "2",
+                      "title": "Link 2",
+                      "url": "https://www.example.com/link2",
+                      "tag": "link",
+                      "thumbnail": "https://www.example.com/link2-thumbnail.jpg",
+                      "like": 0,
+                      "createdAt": "2024-07-15",
+                      "zip":
+                        {
+                          "id": "2",
+                          "title": "Zip 2",
+                          "color": "blue"
+                        },
+                    },
+                  ],
+              }
+        "400":
+          description: 잘못된 요청
+          schema:
+            type: object
+            properties:
+              status:
+                type: integer
+                example: 400
+              isSuccess:
+                type: boolean
+                example: false
+              code:
+                type: integer
+                example: COMMON001
+              message:
+                type: string
+                example: 잘못된 요청입니다
+        "500":
+          description: 서버 에러
+          schema:
+            type: object
+            properties:
+              status:
+                type: integer
+                example: 500
+              isSuccess:
+                type: boolean
+                example: false
+              code:
+                type: integer
+                example: COMMON000
+              message:
+                type: string
+                example: 서버 에러, 관리자에게 문의 바랍니다.

--- a/swagger/recentlist.swagger.yml
+++ b/swagger/recentlist.swagger.yml
@@ -1,0 +1,112 @@
+paths:
+  /list/recent/{userId}:
+    get:
+      tags:
+        - List
+      summary: 사용자의 최근 저장한 링크 조회
+      parameters:
+        - in: path
+          name: userId
+          required: true
+          type: integer
+          description: 사용자 Id
+        - in: query
+          name: sort
+          type: string
+          enum: [recent, past, dictionary, visit]
+          description: 정렬 옵션
+        - in: query
+          name: filter
+          type: string
+          enum: [onlylink, onlytext]
+          description: 필터 옵션
+      responses:
+        "200":
+          description: 최근 링크 조회 성공
+          schema:
+            type: object
+            properties:
+              status:
+                type: integer
+                example: 200
+              isSuccess:
+                type: boolean
+                example: true
+              code:
+                type: integer
+                example: 2000
+              message:
+                type: string
+                example: "success!"
+          data:
+            type: object
+            example:
+              {
+                "links":
+                  [
+                    {
+                      "id": "1",
+                      "title": "Link 1",
+                      "url": "https://www.exaple.com/link1",
+                      "tag": "text",
+                      "thumbnail": "https://www.example.com/link1-thumbnail.jpg",
+                      "like": 1,
+                      "createdAt": "2024-07-15",
+                      "zip":
+                        {
+                          "id": "1",
+                          "title": "Zip 1",
+                          "color": "blue"
+                        },
+                    },
+                    {
+                      "id": "2",
+                      "title": "Link 2",
+                      "url": "https://www.example.com/link2",
+                      "tag": "link",
+                      "thumbnail": "https://www.example.com/link2-thumbnail.jpg",
+                      "like": 0,
+                      "createdAt": "2024-07-15",
+                      "zip":
+                        {
+                          "id": "2",
+                          "title": "Zip 2",
+                          "color": "blue"
+                        },
+                    },
+                  ],
+              }
+        "400":
+          description: 잘못된 요청
+          schema:
+            type: object
+            properties:
+              status:
+                type: integer
+                example: 400
+              isSuccess:
+                type: boolean
+                example: false
+              code:
+                type: integer
+                example: COMMON001
+              message:
+                type: string
+                example: 잘못된 요청입니다
+        "500":
+          description: 서버 에러
+          schema:
+            type: object
+            properties:
+              status:
+                type: integer
+                example: 500
+              isSuccess:
+                type: boolean
+                example: false
+              code:
+                type: integer
+                example: COMMON000
+              message:
+                type: string
+                example: 서버 에러, 관리자에게 문의 바랍니다.


### PR DESCRIPTION
## 관련 이슈

- #23 

## 요약 📝

- 최근 저장, 좋아요 리스트를 구현하였습니다. 

## 상세 내용 🔥

- 최근 저장의 경우 저장한지 (생성날짜가) 현재보다 3일 이내인 링크인 경우에만 조회하도록 설정하였습니다.
- 좋아요한 링크 리스트는 링크의 like=1인 링크인 경우만 조회하도록 설정하였습니다.
- 실시간으로 좋아요를 없애면 바로 없어지는 기능 또는 실시간으로 시간이 지나면 알아서 최근 저장된 리스트를 다시 불러오는 기능은 구현하지 않았습니다. 
- 필터를 적용하지 않을 경우 기본으로 최신순으로 정렬됩니다. 방문자수가 같거나 이름이 같을 경우에도 최신순으로 조회합니다. 

## 리뷰어에게 부탁, 유의사항 🙏

- 기존에 있던 list 파일을 그대로 사용하여 기능을 구현했기에 충돌난 부분이 있을 수 있습니다.. 혹시 문제될 부분 있으면 바로 수정하겠습니다. 
