### PR TITLE
[#15] Feat: 닉네임 중복 처리

### DIFF
--- a/config/response.status.js
+++ b/config/response.status.js
@@ -4,6 +4,7 @@ export const status = {
     // success
     SUCCESS: {status: StatusCodes.OK, "isSuccess": true, "code": 2000, "message": "success!"},
     CREATED: {status: StatusCodes.CREATED, "isSuccess": true, "code": 2000, "message": "create success!"},
+    NICKNAME_VALID: {status: StatusCodes.OK, "isSuccess": true, "code": 2000, "message": "환상적인 닉네임이에요!"},
 
     // error
     // common err
@@ -22,6 +23,9 @@ export const status = {
 
     // alert error
     ALERT_NOT_FOUND: {status: StatusCodes.NOT_FOUND, "isSuccess": false, "code": "ALERT001", "message": "해당 알림을 찾을 수 없습니다." },
-    ALERT_ALREADY_EXIST: {status: StatusCodes.BAD_REQUEST, "isSuccess": false, "code": "ALERT002", "message": "이미 존재하는 알림입니다."} 
+    ALERT_ALREADY_EXIST: {status: StatusCodes.BAD_REQUEST, "isSuccess": false, "code": "ALERT002", "message": "이미 존재하는 알림입니다."},
 
+    // user error
+    USER_NOT_FOUND: {status: StatusCodes.NOT_FOUND, "isSuccess": false, "code": "USER001", "message": "해당 유저를 찾을 수 없습니다." },
+    NICKNAME_DUPLICATED: {status: StatusCodes.BAD_REQUEST, "isSuccess": false, "code": "USER002", "message": "이미 사용중인 유저가 있어요!" },
 };

--- a/index.js
+++ b/index.js
@@ -11,7 +11,6 @@ import { userRouter } from '@routes/user.route.js';
 import { listRouter } from '@routes/list.route.js';
 import { linkRouter } from '@routes/link.route.js';
 import { zipRouter } from '@routes/zip.route.js'
-import { noticeRouter } from '@routes/notice.route';
 
 dotenv.config();
 
@@ -32,7 +31,6 @@ app.use('/user', userRouter);
 app.use('/link', linkRouter);
 app.use('/zips', zipRouter)
 app.use('/alert',alertRouter);
-app.use('/notice', noticeRouter);
 
 /** DB 연결 테스트용 라우팅 */
 app.get('/', async (req, res)=>{

--- a/src/controllers/user.controller.js
+++ b/src/controllers/user.controller.js
@@ -1,7 +1,8 @@
+import { BaseError } from "@config/error";
 import { response } from "@config/response.js";
 import { status } from '@config/response.status.js';
-import { addUserSer } from '@services/user.service.js';
-import { getUserSer, checkNicknameSer } from "@providers/user.provider.js";
+import { addUserSer, checkNicknameSer } from '@services/user.service.js';
+import { getUserSer } from "@providers/user.provider.js";
 
 /** 회원가입 */
 export const addUserCnt = async (req, res, next) => {
@@ -13,8 +14,17 @@ export const getUserCnt = async (req, res, next) => {
     res.send(response(status.SUCCESS, await getUserSer(req.params)));
 }
 
+/** 닉네임 중복 체크 컨트롤러 (query: nickname) */
 export const checkNicknameCnt = async (req, res, next) => {
-    const { nickname } = req.query;
-    console.log(nickname)
-    res.send(response(status.SUCCESS, await checkNicknameSer(nickname)));
+    const nickname = req.query.nickname;
+
+    if (nickname === undefined || nickname === "") {
+        throw new BaseError(status.BAD_REQUEST);
+    }
+
+    try {
+        res.send(response(status.SUCCESS, await checkNicknameSer(nickname)));
+    } catch (error) {
+        throw new BaseError(status.INTERNAL_SERVER_ERROR);
+    }
 }

--- a/src/controllers/user.controller.js
+++ b/src/controllers/user.controller.js
@@ -1,7 +1,7 @@
 import { response } from "@config/response.js";
 import { status } from '@config/response.status.js';
 import { addUserSer } from '@services/user.service.js';
-import { getUserSer } from "@providers/user.provider.js";
+import { getUserSer, checkNicknameSer } from "@providers/user.provider.js";
 
 /** 회원가입 */
 export const addUserCnt = async (req, res, next) => {
@@ -11,4 +11,10 @@ export const addUserCnt = async (req, res, next) => {
 /** 사용자 조회 컨트롤러 (userId) */
 export const getUserCnt = async (req, res, next) => {
     res.send(response(status.SUCCESS, await getUserSer(req.params)));
+}
+
+export const checkNicknameCnt = async (req, res, next) => {
+    const { nickname } = req.query;
+    console.log(nickname)
+    res.send(response(status.SUCCESS, await checkNicknameSer(nickname)));
 }

--- a/src/dtos/user.dto.js
+++ b/src/dtos/user.dto.js
@@ -6,3 +6,11 @@ export const userResponseDTO = (data) => {
         createdAt: data.createdAt,
     }
 }
+
+/** 닉네임 중복 여부 반환 DTO */
+export const nicknameResponseDTO = (data) => {
+    return {
+        isValid: data.count === 0,
+        message: data.count === 0 ? "환상적인 닉네임이에요!" : "이미 사용 중인 유저가 있어요!",
+    }
+}

--- a/src/models/user.dao.js
+++ b/src/models/user.dao.js
@@ -2,7 +2,7 @@ import { BaseError } from '@config/error.js';
 import { status } from '@config/response.status.js';
 import { pool } from '@config/db.config.js';
 
-import { insertUserSql, selectUserSql } from './user.sql.js';
+import { checkNicknameSql, insertUserSql, selectUserSql } from './user.sql.js';
 
 /** 회원가입 DAO, id 리턴 */
 export const addUserDao = async (data) => {
@@ -30,4 +30,15 @@ export const getUserDao = async (userId) => {
     } catch (error) {
         throw new BaseError(status.BAD_REQUEST);
     }   
+}
+
+export const checkNicknameDao = async (nickname) => {
+    try {
+        const conn = await pool.getConnection();
+        const [[result]] = await conn.query(checkNicknameSql, nickname);
+        conn.release();
+        return result;
+    } catch (error) {
+        throw new BaseError(status.BAD_REQUEST);
+    }
 }

--- a/src/models/user.dao.js
+++ b/src/models/user.dao.js
@@ -8,6 +8,13 @@ import { checkNicknameSql, insertUserSql, selectUserSql } from './user.sql.js';
 export const addUserDao = async (data) => {
     try {
         const conn = await pool.getConnection();
+        
+        const [[isValid]] = await conn.query(checkNicknameSql, data.nickname);
+        if (isValid.count > 0) {
+            conn.release();
+            throw new BaseError(status.NICKNAME_DUPLICATED);
+        }
+
         const [result] = await conn.query(insertUserSql, [
             data.kakaoId,
             data.nickname
@@ -28,10 +35,12 @@ export const getUserDao = async (userId) => {
         conn.release();
         return result;
     } catch (error) {
+        console.error(error);
         throw new BaseError(status.BAD_REQUEST);
     }   
 }
 
+/** 닉네임 중복 체크 DAO */
 export const checkNicknameDao = async (nickname) => {
     try {
         const conn = await pool.getConnection();
@@ -39,6 +48,7 @@ export const checkNicknameDao = async (nickname) => {
         conn.release();
         return result;
     } catch (error) {
+        console.error(error);
         throw new BaseError(status.BAD_REQUEST);
     }
 }

--- a/src/models/user.sql.js
+++ b/src/models/user.sql.js
@@ -2,4 +2,4 @@ export const insertUserSql = "INSERT INTO user (kakao_id, nickname, created_at, 
 
 export const selectUserSql = "SELECT * FROM user WHERE id = ?";
 
-export const checkNicknameSql = "SELECT * FROM user WHERE nickname = ?";
+export const checkNicknameSql = "SELECT count(*) as count FROM user WHERE nickname = ?";

--- a/src/models/user.sql.js
+++ b/src/models/user.sql.js
@@ -1,3 +1,5 @@
 export const insertUserSql = "INSERT INTO user (kakao_id, nickname, created_at, updated_at, status) VALUES (?, ?, NOW(), NOW(), 'ACTIVE');";
 
 export const selectUserSql = "SELECT * FROM user WHERE id = ?";
+
+export const checkNicknameSql = "SELECT * FROM user WHERE nickname = ?";

--- a/src/providers/user.provider.js
+++ b/src/providers/user.provider.js
@@ -6,3 +6,9 @@ export const getUserSer = async (req) => {
     const userId = req.userId;
     return userResponseDTO(await getUserDao(userId));
 }
+
+export const checkNicknameSer = async (body) => {
+    return {
+        isExist: false,
+    }
+}

--- a/src/providers/user.provider.js
+++ b/src/providers/user.provider.js
@@ -1,14 +1,16 @@
+import { status } from "@config/response.status";
+import { BaseError } from "@config/error";
 import { userResponseDTO } from "@dtos/user.dto";
 import { getUserDao } from "@models/user.dao";
 
 /** 사용자 정보 조회 서비스 */
 export const getUserSer = async (req) => {
     const userId = req.userId;
-    return userResponseDTO(await getUserDao(userId));
-}
+    const result = await getUserDao(userId);
 
-export const checkNicknameSer = async (body) => {
-    return {
-        isExist: false,
+    if (result === undefined) {
+        throw new BaseError(status.USER_NOT_FOUND);
     }
+
+    return userResponseDTO(await getUserDao(userId));
 }

--- a/src/routes/user.route.js
+++ b/src/routes/user.route.js
@@ -1,9 +1,11 @@
 import express from 'express';
 import asyncHandler from 'express-async-handler';
-import { addUserCnt, getUserCnt } from '@controllers/user.controller.js';
+import { addUserCnt, getUserCnt, checkNicknameCnt } from '@controllers/user.controller.js';
 
 export const userRouter = express.Router();
 
 userRouter.post('/', asyncHandler(addUserCnt));
 
 userRouter.get('/:userId', asyncHandler(getUserCnt));
+
+userRouter.get('/nickname', asyncHandler(checkNicknameCnt));

--- a/src/routes/user.route.js
+++ b/src/routes/user.route.js
@@ -4,8 +4,7 @@ import { addUserCnt, getUserCnt, checkNicknameCnt } from '@controllers/user.cont
 
 export const userRouter = express.Router();
 
-userRouter.post('/', asyncHandler(addUserCnt));
+userRouter.get("/:userId", asyncHandler(getUserCnt)); // 정보 조회
+userRouter.get("/", asyncHandler(checkNicknameCnt)); // 닉네임 중복 체크
 
-userRouter.get('/:userId', asyncHandler(getUserCnt));
-
-userRouter.get('/nickname', asyncHandler(checkNicknameCnt));
+userRouter.post("/", asyncHandler(addUserCnt)); // 회원가입

--- a/src/services/user.service.js
+++ b/src/services/user.service.js
@@ -1,5 +1,7 @@
-import { userResponseDTO } from '@dtos/user.dto.js';
-import { addUserDao, getUserDao } from '@models/user.dao.js';
+import { status } from "@config/response.status";
+import { BaseError } from "@config/error";
+import { userResponseDTO, nicknameResponseDTO } from '@dtos/user.dto.js';
+import { addUserDao, getUserDao, checkNicknameDao } from '@models/user.dao.js';
 
 /** 사용자 회원가입 서비스 */
 export const addUserSer = async (body) => {
@@ -7,8 +9,26 @@ export const addUserSer = async (body) => {
     
     // id 리턴
     const joinUserId = await addUserDao({
+        "key": body.key,
         "kakaoId": kakaoId,
         "nickname": body.nickname,
     });
     return userResponseDTO(await getUserDao(joinUserId));
 };
+
+/** 닉네임 중복 체크 */
+export const checkNicknameSer = async (nickname) => {
+    return nicknameResponseDTO(await checkNicknameDao(nickname));
+}
+
+/** 사용자 정보 조회 서비스 */
+export const getUserSer = async (req) => {
+    const userId = req.userId;
+    const result = await getUserDao(userId);
+
+    if (result === undefined) {
+        throw new BaseError(status.USER_NOT_FOUND);
+    }
+
+    return userResponseDTO(await getUserDao(userId));
+}

--- a/swagger/user.swagger.yml
+++ b/swagger/user.swagger.yml
@@ -1,22 +1,89 @@
 paths:
-  /user:
+  /user/login:
     post:
       tags:
         - User
-      summary: 사용자 회원가입
+      summary: 소셜 로그인
+      description: | 
+        카카오 authCode를 받아 소셜 로그인을 진행합니다. 
+        기존 유저라면 200과 함께 토큰을 반환하며, 신규 유저라면 400 에러와 함께 회원가입을 위한 key를 반환합니다.
       parameters:
         - in: body
           name: body
+          description: 카카오 authCode
           required: true
           schema:
             type: object
             properties:
-              nickname:
+              authCode: 
                 type: string
-                example: 'nickname'
       responses:
         "200":
-          description: 사용자 회원가입 성공
+          description: 소셜 로그인 성공
+          schema:
+            type: object
+            properties:
+              accessToken: 
+                type: string
+              refreshToken: 
+                type: string
+        "400":
+          description: 소셜 로그인 실패
+          schema:
+            type: object
+            properties:
+              status:
+                type: integer
+                example: 400
+              isSuccess:
+                type: boolean
+                example: false
+              code:
+                type: integer
+                example: COMMON001
+              message:
+                type: string
+                example: "회원가입을 위한 key를 반환합니다."
+              data:
+                type: object
+                example: 
+                  {
+                    "key": string
+                  }
+        "500":
+          description: 서버 에러
+          schema:
+            type: object
+            properties:
+              status:
+                type: integer
+                example: 500
+              isSuccess:
+                type: boolean
+                example: false
+              code:
+                type: integer
+                example: COMMON000
+              message:
+                type: string
+                example: 서버 에러, 관리자에게 문의 바랍니다.
+  /user/nickname:
+    get:
+      tags:
+        - User
+      summary: 닉네임 중복 확인
+      description: |
+        사용자 회원가입 또는 정보 수정 시 입력한 닉네임이 중복되는지 확인합니다.
+        body 없이 status와 message만 내려가며, 닉네임이 중복된다면 400 에러를 반환합니다.
+      parameters:
+        - in: query
+          name: nickname
+          required: true
+          type: string
+          description: 사용자 닉네임
+      responses:
+        "200":
+          description: 닉네임 중복 없음
           schema:
             type: object
             properties:
@@ -31,18 +98,70 @@ paths:
                 example: 2000
               message:
                 type: string
-                example: "success!"
-            data:
-              type: object
-              example:
-                {
-                  "user":
-                    {
-                      "id": "1",
-                      "email": "example@example.com",
-                      "createdAt": "2024-07-15"
-                    }
-                }
+                example: "환상적인 닉네임이에요!"
+        "400":
+          description: 중복된 닉네임
+          schema:
+            type: object
+            properties:
+              status:
+                type: integer
+                example: 400
+              isSuccess:
+                type: boolean
+                example: false
+              code:
+                type: integer
+                example: NICKNAME_DUPLICATED
+              message:
+                type: string
+                example: "이미 사용중인 유저가 있어요!"
+        "500":
+          description: 서버 에러
+          schema:
+            type: object
+            properties:
+              status:
+                type: integer
+                example: 500
+              isSuccess:
+                type: boolean
+                example: false
+              code:
+                type: integer
+                example: COMMON000
+              message:
+                type: string
+                example: 서버 에러, 관리자에게 문의 바랍니다.
+  /user:
+    post:
+      tags:
+        - User
+      summary: 사용자 회원가입
+      description: |
+        사용자 회원가입을 진행합니다. 로그인 실패 시 내려간 key값과 닉네임을 받아 토큰을 반환합니다.
+      parameters:
+        - in: body
+          name: body
+          description: 회원가입 key 및 사용자 닉네임
+          required: true
+          schema:
+            type: object
+            properties:
+              nickname:
+                type: string
+              key:
+                type: string
+      responses:
+        "200":
+          description: 사용자 회원가입 성공
+          schema:
+            type: object
+            properties:
+              accessToken: 
+                type: string
+              refreshToken: 
+                type: string
         "400":
           description: 잘못된 요청
           schema:
@@ -82,6 +201,7 @@ paths:
       tags:
         - User
       summary: 사용자 정보 조회
+      description: 사용자 정보 조회를 위한 임시 API 입니다.
       parameters:
         - in: path
           name: userId
@@ -94,29 +214,12 @@ paths:
           schema:
             type: object
             properties:
-              status:
+              userId:
                 type: integer
-                example: 200
-              isSuccess:
-                type: boolean
-                example: true
-              code:
-                type: integer
-                example: 2000
-              message:
+              nickname:
                 type: string
-                example: "success!"
-              data:
-                type: object
-                example:
-                  {
-                    "user":
-                    {
-                      "userId": "1",
-                      "nickname": "example",
-                      "createdAt": "2024-07-15"
-                    }
-                  }
+              createdAt:
+                type: string
         "400":
           description: 잘못된 요청
           schema:

--- a/swagger/user.swagger.yml
+++ b/swagger/user.swagger.yml
@@ -6,7 +6,7 @@ paths:
       summary: 소셜 로그인
       description: | 
         카카오 authCode를 받아 소셜 로그인을 진행합니다. 
-        기존 유저라면 200과 함께 토큰을 반환하며, 신규 유저라면 400 에러와 함께 회원가입을 위한 key를 반환합니다.
+        기존 유저라면 토큰을 반환하며, 신규 유저라면 회원가입을 위한 key를 반환합니다.
       parameters:
         - in: body
           name: body
@@ -34,16 +34,16 @@ paths:
             properties:
               status:
                 type: integer
-                example: 400
+                example: 404
               isSuccess:
                 type: boolean
                 example: false
               code:
                 type: integer
-                example: COMMON001
+                example: USER001
               message:
                 type: string
-                example: "회원가입을 위한 key를 반환합니다."
+                example: 해당 유저를 찾을 수 없습니다.
               data:
                 type: object
                 example: 
@@ -67,14 +67,14 @@ paths:
               message:
                 type: string
                 example: 서버 에러, 관리자에게 문의 바랍니다.
-  /user/nickname:
+  /user:
     get:
       tags:
         - User
       summary: 닉네임 중복 확인
       description: |
         사용자 회원가입 또는 정보 수정 시 입력한 닉네임이 중복되는지 확인합니다.
-        body 없이 status와 message만 내려가며, 닉네임이 중복된다면 400 에러를 반환합니다.
+        중복 여부와 메시지를 body에 담아 보냅니다.
       parameters:
         - in: query
           name: nickname
@@ -83,24 +83,18 @@ paths:
           description: 사용자 닉네임
       responses:
         "200":
-          description: 닉네임 중복 없음
+          description: 닉네임 조회 완료
           schema:
             type: object
             properties:
-              status:
-                type: integer
-                example: 200
-              isSuccess:
+              isValid:
                 type: boolean
                 example: true
-              code:
-                type: integer
-                example: 2000
               message:
                 type: string
-                example: "환상적인 닉네임이에요!"
+                example: 환상적인 닉네임이에요!
         "400":
-          description: 중복된 닉네임
+          description: 잘못된 요청
           schema:
             type: object
             properties:
@@ -112,10 +106,10 @@ paths:
                 example: false
               code:
                 type: integer
-                example: NICKNAME_DUPLICATED
+                example: COMMON001
               message:
                 type: string
-                example: "이미 사용중인 유저가 있어요!"
+                example: 잘못된 요청입니다.
         "500":
           description: 서버 에러
           schema:
@@ -133,7 +127,6 @@ paths:
               message:
                 type: string
                 example: 서버 에러, 관리자에게 문의 바랍니다.
-  /user:
     post:
       tags:
         - User


### PR DESCRIPTION
## 관련 이슈

- #15

## 요약 📝

- 닉네임 중복 처리 및 User 관련 요청, 응답, 명세서 수정 작업

## 상세 내용 🔥

- 닉네임 중복 처리 api를 구현하였습니다.
  - 기존에는 닉네임 중복 시 400 에러와 함께 메시지로 내려주려 했으나, 에러 출력 과정에서의 오류로 인해 성공/중복 모두 200으로, body의 isValid와 메시지가 구분되어 내려가게 수정하였습니다.
- User 관련 status를 수정하였습니다.
  - 찾으려는 유저가 없을 시 출력하는 USER_NOT_FOUND, 중복된 닉네임일 시 출력하는 NICKNAME_DUPLICATED를 추가하였습니다.
- User 관련 기존 api를 수정하였습니다.
  - 회원가입 시에도 닉네임 중복 검증을 추가하였습니다.
  - (구현X) 로그인 시 프론트에서 authcode를 받아, 유저 존재 시 200과 함께 토큰, 신규 유저시 400 에러와 함께 회원가입 시 사용할 key를 보냅니다. 그러나 해당 부분 또한 앞선 에러출력 오류로 인해 변경될 수 있습니다.
  - (구현X) 회원가입 시 닉네임, key를 요청값으로 받아, 기존 세션에 저장된 key값으로 검증하여 가입 처리할 예정입니다.

## 리뷰어에게 부탁, 유의사항 🙏

- 
