### PR TITLE
[#28] Fix: 닉네임 중복 api 수정

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,11 +6,12 @@ import { specs } from '@config/swagger.config.js';
 import { status } from '@config/response.status.js';
 import { response } from '@config/response.js';
 import { pool } from '@config/db.config.js';
-import {alertRouter} from '@routes/alert.route.js';
+import { alertRouter } from '@routes/alert.route.js';
 import { userRouter } from '@routes/user.route.js';
 import { listRouter } from '@routes/list.route.js';
 import { linkRouter } from '@routes/link.route.js';
 import { zipRouter } from '@routes/zip.route.js'
+import { noticeRouter } from '@routes/notice.route';
 
 dotenv.config();
 
@@ -29,8 +30,9 @@ app.use('/api-docs', SwaggerUi.serve, SwaggerUi.setup(specs));
 app.use('/list', listRouter);
 app.use('/user', userRouter);
 app.use('/link', linkRouter);
-app.use('/zips', zipRouter)
-app.use('/alert',alertRouter);
+app.use('/zips', zipRouter);
+app.use('/alert', alertRouter);
+app.use('/notice', noticeRouter);
 
 /** DB 연결 테스트용 라우팅 */
 app.get('/', async (req, res)=>{

--- a/src/controllers/user.controller.js
+++ b/src/controllers/user.controller.js
@@ -18,13 +18,10 @@ export const getUserCnt = async (req, res, next) => {
 export const checkNicknameCnt = async (req, res, next) => {
     const nickname = req.query.nickname;
 
+    // 요청값(닉네임)이 없는 경우
     if (nickname === undefined || nickname === "") {
         throw new BaseError(status.BAD_REQUEST);
     }
 
-    try {
-        res.send(response(status.SUCCESS, await checkNicknameSer(nickname)));
-    } catch (error) {
-        throw new BaseError(status.INTERNAL_SERVER_ERROR);
-    }
+    return res.send(response(status.NICKNAME_VALID, await checkNicknameSer(nickname)));
 }

--- a/src/dtos/user.dto.js
+++ b/src/dtos/user.dto.js
@@ -6,11 +6,3 @@ export const userResponseDTO = (data) => {
         createdAt: data.createdAt,
     }
 }
-
-/** 닉네임 중복 여부 반환 DTO */
-export const nicknameResponseDTO = (data) => {
-    return {
-        isValid: data.count === 0,
-        message: data.count === 0 ? "환상적인 닉네임이에요!" : "이미 사용 중인 유저가 있어요!",
-    }
-}

--- a/src/models/user.dao.js
+++ b/src/models/user.dao.js
@@ -46,7 +46,7 @@ export const checkNicknameDao = async (nickname) => {
         const conn = await pool.getConnection();
         const [[result]] = await conn.query(checkNicknameSql, nickname);
         conn.release();
-        return result;
+        return result; // count 반환
     } catch (error) {
         console.error(error);
         throw new BaseError(status.BAD_REQUEST);

--- a/src/services/user.service.js
+++ b/src/services/user.service.js
@@ -1,6 +1,6 @@
 import { status } from "@config/response.status";
 import { BaseError } from "@config/error";
-import { userResponseDTO, nicknameResponseDTO } from '@dtos/user.dto.js';
+import { userResponseDTO } from '@dtos/user.dto.js';
 import { addUserDao, getUserDao, checkNicknameDao } from '@models/user.dao.js';
 
 /** 사용자 회원가입 서비스 */
@@ -16,9 +16,14 @@ export const addUserSer = async (body) => {
     return userResponseDTO(await getUserDao(joinUserId));
 };
 
-/** 닉네임 중복 체크 */
+/** 닉네임 중복 여부: 서비스 단에서 분기 처리 */
 export const checkNicknameSer = async (nickname) => {
-    return nicknameResponseDTO(await checkNicknameDao(nickname));
+    const result = await checkNicknameDao(nickname);
+    // 닉네임 중복 시 throw
+    if (result.count > 0) {
+        throw new BaseError(status.NICKNAME_DUPLICATED);
+    }
+    return true;
 }
 
 /** 사용자 정보 조회 서비스 */

--- a/swagger/user.swagger.yml
+++ b/swagger/user.swagger.yml
@@ -74,7 +74,7 @@ paths:
       summary: 닉네임 중복 확인
       description: |
         사용자 회원가입 또는 정보 수정 시 입력한 닉네임이 중복되는지 확인합니다.
-        중복 여부와 메시지를 body에 담아 보냅니다.
+        성공 시 200과 함께 메시지를, 닉네임 중복 시 400 에러와 함께 메시지를 반환합니다.
       parameters:
         - in: query
           name: nickname
@@ -83,18 +83,24 @@ paths:
           description: 사용자 닉네임
       responses:
         "200":
-          description: 닉네임 조회 완료
+          description: 닉네임 중복 없음
           schema:
             type: object
             properties:
-              isValid:
+              status:
+                type: integer
+                example: 200
+              isSuccess:
                 type: boolean
                 example: true
+              code:
+                type: integer
+                example: 2000
               message:
                 type: string
                 example: 환상적인 닉네임이에요!
         "400":
-          description: 잘못된 요청
+          description: 닉네임 중복
           schema:
             type: object
             properties:
@@ -106,10 +112,10 @@ paths:
                 example: false
               code:
                 type: integer
-                example: COMMON001
+                example: USER002
               message:
                 type: string
-                example: 잘못된 요청입니다.
+                example: 이미 사용 중인 닉네임이에요!
         "500":
           description: 서버 에러
           schema:


### PR DESCRIPTION
## 관련 이슈

- #28

## 요약 📝

- 닉네임 중복 api와 index.js 수정

## 상세 내용 🔥

- 닉네임 중복 여부의 분기 처리를 이제 기존 설계처럼 Service 에서 수행합니다!
- 링크 의견을 참고하여 try-catch문을 Service에서 수행하고, 컨트롤러에서는 요청값(닉네임)의 유효함만 확인하여 throw 합니다.
- 이에 맞게 스웨거 명세서도 기존대로 롤백하였습니다.
- index.js의 noticeRouter 실종사건을 해결했습니다.

## 리뷰어에게 부탁, 유의사항 🙏

- 꼼꼼한 코드확인 다시한번 감사드립니다 ㅜㅜ 아녔으면 이대로 갈 뻔 했네요
