### PR TITLE
[#31] Feat: Zip 수정기능 구현

### DIFF
--- a/config/response.status.js
+++ b/config/response.status.js
@@ -5,6 +5,7 @@ export const status = {
     SUCCESS: {status: StatusCodes.OK, "isSuccess": true, "code": 2000, "message": "success!"},
     CREATED: {status: StatusCodes.CREATED, "isSuccess": true, "code": 2000, "message": "create success!"},
     NICKNAME_VALID: {status: StatusCodes.OK, "isSuccess": true, "code": 2000, "message": "환상적인 닉네임이에요!"},
+    UPDATED: {status: StatusCodes.UPDATED, "isSuccess": true, "code": 2000, "message": "update success!"},
 
     // error
     // common err
@@ -28,4 +29,5 @@ export const status = {
     // user error
     USER_NOT_FOUND: {status: StatusCodes.NOT_FOUND, "isSuccess": false, "code": "USER001", "message": "해당 유저를 찾을 수 없습니다." },
     NICKNAME_DUPLICATED: {status: StatusCodes.BAD_REQUEST, "isSuccess": false, "code": "USER002", "message": "이미 사용중인 유저가 있어요!" },
+    
 };

--- a/src/controllers/zip.controller.js
+++ b/src/controllers/zip.controller.js
@@ -1,7 +1,7 @@
 import { response } from '@config/response.js';
 import { status } from '@config/response.status.js';
-import { createZipReqDto, deleteZipReqDto } from '@dtos/zip.dto.js';
-import { createZipService, deleteZipService } from '@services/zip.service.js';
+import { createZipReqDto, deleteZipReqDto, editZipReqDto } from '@dtos/zip.dto.js';
+import { createZipService, deleteZipService, editZipService } from '@services/zip.service.js';
 import { getZipsProvider } from '@providers/zip.provider.js';
 
 // POST Controller
@@ -21,4 +21,10 @@ export const deleteZipController = async(req, res, next) => {
 /** Zip 조회 controller */
 export const getZipsController = async(req, res, next) => {
     return res.send(response(status.SUCCESS, await getZipsProvider(req)));
+}
+
+// PATCH Controller
+/** Zip 수정 controller */
+export const editZipController = async(req, res, next) => {
+    return res.send(response(status.UPDATED, await editZipService(editZipReqDto(req.body))));
 }

--- a/src/dtos/zip.dto.js
+++ b/src/dtos/zip.dto.js
@@ -39,3 +39,19 @@ export const getZipResDto = (zip) => {
         link_count : zip.link_count
     };
 }
+
+// PATCH API DTO
+export const editZipReqDto = (body) => {
+    return {
+        user_id : body.user_id,
+        zip_id : body.id,
+        title : body.title,
+        color : body.color
+    };
+}
+
+export const editZipResDto = (zip_id) => {
+    return {
+        message : `${zip_id} zip이 수정 되었습니다.`
+    };
+}

--- a/src/models/zip.dao.js
+++ b/src/models/zip.dao.js
@@ -1,7 +1,7 @@
 import { pool } from '@config/db.config.js';
 import { BaseError } from '@config/error.js';
 import { status } from '@config/response.status.js';
-import { createZipSql, deleteZipSql, testZipDeletableSql, getZipsSql } from '@models/zip.sql.js';
+import { createZipSql, deleteZipSql, testZipDeletableSql, getZipsSql, editZipSql } from '@models/zip.sql.js';
 
 // POST API
 /** Zip 생성 Dao */
@@ -98,5 +98,23 @@ export const getZipsDao = async(sort, user_id) => {
         else{
             throw err;
         }
+    }
+}
+
+//PATCH API
+/** Zip 수정 Dao */
+export const editZipDao = async(reqDto) => {
+    try{
+        const conn = await pool.getConnection();
+        await conn.query(editZipSql, [
+            reqDto.title,
+            reqDto.color,
+            reqDto.user_id,
+            reqDto.zip_id
+        ])
+        conn.release();
+        return reqDto.zip_id;
+    } catch(err) {
+        throw new BaseError(status.INTERNAL_SERVER_ERROR);
     }
 }

--- a/src/models/zip.sql.js
+++ b/src/models/zip.sql.js
@@ -21,3 +21,7 @@ export const testZipDeletableSql =
 export const deleteZipSql = 
     "DELETE FROM zip WHERE id = ? AND user_id = ? AND status != 'default'";
 
+// PATCH SQL
+export const editZipSql =
+    "UPDATE zip SET title = ?, color = ? WHERE user_id = ? AND id = ?";
+

--- a/src/routes/zip.route.js
+++ b/src/routes/zip.route.js
@@ -3,7 +3,8 @@ import asyncHandler from 'express-async-handler';
 import {
     createZipController,
     deleteZipController,
-    getZipsController
+    getZipsController,
+    editZipController
 } from '@controllers/zip.controller.js';
 
 
@@ -17,5 +18,8 @@ zipRouter.delete("/", asyncHandler(deleteZipController));
 
 /** GET API */
 zipRouter.get("/", asyncHandler(getZipsController));
+
+/** PATCH API */
+zipRouter.patch("/", asyncHandler(editZipController));
 
 

--- a/src/services/zip.service.js
+++ b/src/services/zip.service.js
@@ -1,7 +1,7 @@
 import { BaseError } from '@config/error.js';
 import { status } from '@config/response.status.js';
-import { createZipDao, deleteZipDao, testZipDeletableDao } from '@models/zip.dao.js';
-import { createZipResDto, deleteZipResDto } from '@dtos/zip.dto.js';
+import { createZipDao, deleteZipDao, testZipDeletableDao, editZipDao } from '@models/zip.dao.js';
+import { createZipResDto, deleteZipResDto, editZipResDto } from '@dtos/zip.dto.js';
 
 // POST API
 /** Zip 생성 service */
@@ -12,9 +12,21 @@ export const createZipService = async (dto) => {
 // DELETE API
 /** Zip 삭제 service */
 export const deleteZipService = async (dto) => {
+    // 해당 zip이 default zip인지 검증
     dto = await testZipDeletableDao(dto);
     if(dto.status == 'default'){
         throw new BaseError(status.BAD_REQUEST);
     };
     return deleteZipResDto(await deleteZipDao(dto));
 };
+
+// PATCH API
+/** Zip 수정 service */
+export const editZipService = async (dto) => {
+    // 해당 zip이 default zip인지 검증
+    dto = await testZipDeletableDao(dto);
+    if(dto.status === 'default'){
+        throw new BaseError(status.FAILED_TO_UPDATE);
+    };
+    return editZipResDto(await editZipDao(dto));
+}


### PR DESCRIPTION
## 관련 이슈

- #31 

## 요약 📝

- Zip의 제목과 색을 수정할 수 있는 API 구현

## 상세 내용 🔥

- Zip을 수정하려 할 때 우선 Default zip인 빠른저장 Zip은 수정이 불가 하도록 검증을 한후 수정하려는 Zip이 만약 Custom Zip이면 수정을 하도록 구현하였다
- response.status.js에서 update가 성공시에 UPDATED를 추가하였다

## 리뷰어에게 부탁, 유의사항 🙏

- 수정관련 API 완료 했습니다 코드보시고 이상있다거나 다른방식의 구현이 더 좋겠다 싶으시면 조언 부탁드립니다.
- 궁금한게 zip수정시 sql에서 user_id를 넘겨주지 않아도 zip의 id만으로 식별해서 수정이 가능한데 user_id를 넘겨주어서 where 절에 조건을 넣는게 너무 과한걸까요? 제 생각에는 혹시 어떤 유저가 다른유저의 zip을 수정할 수 있는 가능성을 아예 배제 해보려고 그렇게 한건데 어떻게 생각하시나요?
