### PR TITLE
[#40] Feat: 인증 미들웨어 구성

### DIFF
--- a/config/authMiddleware.js
+++ b/config/authMiddleware.js
@@ -1,0 +1,18 @@
+import jwt from 'jsonwebtoken';
+import { status } from './response.status.js';
+import { BaseError } from './error.js';
+
+export const tokenAuthMiddleware = (req, res, next) => {
+    const token = req.headers['authorization'] || req.headers['Authorization'];
+    if (!token) {
+        throw new BaseError(status.TOKEN_INVALID);
+    }
+
+    jwt.verify(token, process.env.JWT_SECRET, (err, decoded) => {
+        if (err) {
+            throw new BaseError(status.UNAUTHORIZED);
+        }
+        req.userId = decoded.userId;
+        next();
+    })
+}

--- a/config/authMiddleware.js
+++ b/config/authMiddleware.js
@@ -2,6 +2,7 @@ import jwt from 'jsonwebtoken';
 import { status } from './response.status.js';
 import { BaseError } from './error.js';
 
+/** 토큰 검증 미들웨어, req.userId 반환 */
 export const tokenAuthMiddleware = (req, res, next) => {
     const token = req.headers['authorization'] || req.headers['Authorization'];
     if (!token) {

--- a/config/response.status.js
+++ b/config/response.status.js
@@ -34,7 +34,11 @@ export const status = {
     // user error
     USER_NOT_FOUND: {status: StatusCodes.NOT_FOUND, "isSuccess": false, "code": "USER001", "message": "해당 유저를 찾을 수 없습니다." },
     NICKNAME_DUPLICATED: {status: StatusCodes.BAD_REQUEST, "isSuccess": false, "code": "USER002", "message": "이미 사용중인 유저가 있어요!" },
-    KAKAO_TOKEN_ERROR: {status: StatusCodes.BAD_REQUEST, "isSuccess": false, "code": "USER003", "message": "카카오 토큰 발급에 실패했습니다." },
-    SERVER_TOKEN_ERROR: {status: StatusCodes.BAD_REQUEST, "isSuccess": false, "code": "USER004", "message": "서버 토큰 발급에 실패했습니다." },
-    INVALID_KEY: {status: StatusCodes.BAD_REQUEST, "isSuccess": false, "code": "USER005", "message": "유효하지 않은 키입니다." },
+    INVALID_KEY: {status: StatusCodes.BAD_REQUEST, "isSuccess": false, "code": "USER003", "message": "유효하지 않은 키입니다." },
+
+    // token error
+    KAKAO_TOKEN_ERROR: {status: StatusCodes.BAD_REQUEST, "isSuccess": false, "code": "TOKEN001", "message": "카카오 토큰 발급에 실패했습니다." },
+    SERVER_TOKEN_ERROR: {status: StatusCodes.BAD_REQUEST, "isSuccess": false, "code": "TOKEN002", "message": "서버 토큰 발급에 실패했습니다." },
+    TOKEN_INVALID: {status: StatusCodes.UNAUTHORIZED, "isSuccess": false, "code": "TOKEN003", "message": "유효하지 않은 토큰입니다." },
+    TOKEN_EXPIRED: {status: StatusCodes.UNAUTHORIZED, "isSuccess": false, "code": "TOKEN004", "message": "토큰이 만료되었습니다." },
 };

--- a/config/swagger.config.js
+++ b/config/swagger.config.js
@@ -2,13 +2,27 @@ import SwaggerJsdoc from "swagger-jsdoc";
 
 const options = {
     definition: {
+        swagger: '2.0',
         info: {
             title: 'Link Zip API',
             version: '1.0.0',
             description: 'Link Zip API with express, API 설명'
         },
         host: 'localhost:3000',
-        basepath: '../'
+        basepath: '../',
+        securityDefinitions: {
+            bearerAuth: {
+                type: 'apiKey',
+                name: 'Authorization',
+                in: 'header',
+                description: '로그인 및 회원가입으로 발급받은 토큰을 입력해주세요.'
+            }
+        },
+        security: [
+            {
+                bearerAuth: []
+            }
+        ]
     },
     apis: ['./src/routes/*.js', './swagger/*']
 };

--- a/index.js
+++ b/index.js
@@ -2,12 +2,14 @@ import dotenv from 'dotenv';
 import express from 'express'
 import cors from 'cors';
 import SwaggerUi from 'swagger-ui-express';
+import asyncHandler from 'express-async-handler';
 
 import '@config/global.js';
 import { specs } from '@config/swagger.config.js';
 import { status } from '@config/response.status.js';
 import { response } from '@config/response.js';
 import { pool } from '@config/db.config.js';
+import { tokenAuthMiddleware } from '@config/authMiddleware';
 
 import { alertRouter } from '@routes/alert.route.js';
 import { userRouter } from '@routes/user.route.js';
@@ -15,6 +17,8 @@ import { listRouter } from '@routes/list.route.js';
 import { linkRouter } from '@routes/link.route.js';
 import { zipRouter } from '@routes/zip.route.js'
 import { noticeRouter } from '@routes/notice.route';
+
+import { addUserCnt, checkNicknameCnt, kakaoLoginCnt } from '@controllers/user.controller';
 
 dotenv.config();
 
@@ -27,7 +31,14 @@ app.use(express.json());                    // request의 본문을 json으로 �
 app.use(express.urlencoded({extended: true})); // 단순 객체 문자열 형태로 본문 데이터 해석
 
 
+// 토큰 검증 예외 라우트
+app.post('/user/login', asyncHandler(kakaoLoginCnt)); // 로그인
+app.get('/user', asyncHandler(checkNicknameCnt)); // 닉네임 중복 체크
+app.post('/user', asyncHandler(addUserCnt)); // 회원가입
 app.use('/api-docs', SwaggerUi.serve, SwaggerUi.setup(specs));
+
+// 모든 route에 대해 검증 미들웨어 적용
+app.use(tokenAuthMiddleware);
 
 // router setting
 app.use('/list', listRouter);

--- a/src/controllers/alert.controller.js
+++ b/src/controllers/alert.controller.js
@@ -1,17 +1,17 @@
 // src/routes/alert.controller.js
-import { response } from "../../config/response.js";
-import { status } from "../../config/response.status.js";
+import { response } from "@config/response.js";
+import { status } from "@config/response.status.js";
 
 import { prepareAlertData, alertPreview, checkAlert, eraseAlert } from "../services/alert.service.js";
 
 export const createAlert = async (req,res,next) => {
     console.log("새 알림을 생성합니다.");
-    res.send(response(status.SUCCESS, await prepareAlertData(req)));
+    res.send(response(status.SUCCESS, await prepareAlertData(req.userId, req.body)));
 }
 
 export const userAlert = async (req,res,next) => {
-    console.log("알람을 조회합니다.");
-    res.send(response(status.SUCCESS, await alertPreview(req)));
+    console.log(req.userId + "번 유저 알람을 조회합니다.");
+    res.send(response(status.SUCCESS, await alertPreview(req.userId)));
 }
 
 export const confirmAlert = async (req,res,next) => {

--- a/src/controllers/alert.controller.js
+++ b/src/controllers/alert.controller.js
@@ -6,12 +6,12 @@ import { prepareAlertData, alertPreview, checkAlert, eraseAlert } from "../servi
 
 export const createAlert = async (req,res,next) => {
     console.log("새 알림을 생성합니다.");
-    res.send(response(status.SUCCESS, await prepareAlertData(req.body)));
+    res.send(response(status.SUCCESS, await prepareAlertData(req)));
 }
 
 export const userAlert = async (req,res,next) => {
     console.log("알람을 조회합니다.");
-    res.send(response(status.SUCCESS, await alertPreview(req.query)));
+    res.send(response(status.SUCCESS, await alertPreview(req)));
 }
 
 export const confirmAlert = async (req,res,next) => {

--- a/src/controllers/link.controller.js
+++ b/src/controllers/link.controller.js
@@ -4,9 +4,9 @@ import { BaseError } from "@config/error";
 import { createNewLinkSer, deleteLinkByIdSer, generateUrlSummary, getLinkByIdSer, getLinksSer, updateLikeSer, updateVisitSer, updateZipIdSer } from "@services/link.service";
 
 
-export const getLinksCnt = async  (req, res) => {
+export const getLinksCnt = async (req, res) => {
     const zip_id = req.params.zip_id;
-    const user_id = req.params.user_id; // 추후 토큰에서 가져오는 방법으로 변경
+    const user_id = req.userId;
     const tag = req.query.tag;
     
     try {
@@ -44,7 +44,7 @@ export const getSummaryCnt = async (req,res) => {
 export const createNewLinkCnt = async (req, res) => {
     // text 정보를 받아온 경우 tag: text 로 아니면 link로 저장
     try {
-        res.send(response(status.CREATED, await createNewLinkSer(req.body)));
+        res.send(response(status.CREATED, await createNewLinkSer(req.userId, req.body)));
     } catch (err) {
         return BaseError(status.FAILED_TO_CREATE);
     }

--- a/src/controllers/list.controller.js
+++ b/src/controllers/list.controller.js
@@ -5,13 +5,13 @@ import { status } from "@config/response.status.js";
 import { getUnviewList, getLikeList, getRecentList } from "../providers/list.provider.js";
 
 export const viewUnviewList = async (req,res,next) => {//미열람 링크 리스트 조회
-    res.send(response(status.SUCCESS, await getUnviewList(req.params, req.query)));
+    res.send(response(status.SUCCESS, await getUnviewList(req.userId, req.query)));
 }
 
 export const viewLikeList = async(req,res)=>{
-    res.send(response(status.SUCCESS, await getLikeList(req.params, req.query)))
+    res.send(response(status.SUCCESS, await getLikeList(req.userId, req.query)))
 }
 
 export const viewRecentList = async(req,res)=>{
-    res.send(response(status.SUCCESS, await getRecentList(req.params, req.query)))
+    res.send(response(status.SUCCESS, await getRecentList(req.userId, req.query)))
 }

--- a/src/controllers/user.controller.js
+++ b/src/controllers/user.controller.js
@@ -49,7 +49,7 @@ export const addUserCnt = async (req, res, next) => {
 
 /** 사용자 조회 컨트롤러 (userId) */
 export const getUserCnt = async (req, res, next) => {
-    res.send(response(status.SUCCESS, await getUserSer(req.params)));
+    res.send(response(status.SUCCESS, await getUserSer(req.userId)));
 }
 
 /** 닉네임 중복 체크 컨트롤러 (query: nickname) */

--- a/src/controllers/user.controller.js
+++ b/src/controllers/user.controller.js
@@ -12,7 +12,7 @@ export const kakaoLoginCnt = async (req, res, next) => {
     const result = await getUserByKakaoId(kakaoUserInfo.id); // 신규 유저일 시 여기서 throw
 
     const payload = {
-        userId: result.id,
+        userId: result.userId,
         nickname: result.nickname,
         kakaoId: kakaoUserInfo.id,
         connectedAt: kakaoUserInfo.connected_at,
@@ -31,7 +31,7 @@ export const addUserCnt = async (req, res, next) => {
     const result = await addUserSer(req.body); // 회원가입 리턴값
 
     const payload = {
-        userId: result.id,
+        userId: result.userId,
         nickname: result.nickname,
         kakaoId: result.kakaoId,
         connectedAt: result.createdAt,

--- a/src/controllers/zip.controller.js
+++ b/src/controllers/zip.controller.js
@@ -7,14 +7,14 @@ import { getZipsProvider } from '@providers/zip.provider.js';
 // POST Controller
 /** Zip 생성 controller */
 export const createZipController = async(req, res, next) => {
-    return res.send(response(status.SUCCESS, await createZipService(createZipReqDto(req.body))));
+    return res.send(response(status.SUCCESS, await createZipService(createZipReqDto(req.userId, req.body))));
 };
 
 
 // DELETE Controller
 /** Zip 삭제 controller */
 export const deleteZipController = async(req, res, next) => {
-    return res.send(response(status.SUCCESS, await deleteZipService(deleteZipReqDto(req.body))));
+    return res.send(response(status.SUCCESS, await deleteZipService(deleteZipReqDto(req.userId, req.body))));
 };
 
 // GET Controller
@@ -26,5 +26,5 @@ export const getZipsController = async(req, res, next) => {
 // PATCH Controller
 /** Zip 수정 controller */
 export const editZipController = async(req, res, next) => {
-    return res.send(response(status.UPDATED, await editZipService(editZipReqDto(req.body))));
+    return res.send(response(status.UPDATED, await editZipService(editZipReqDto(req.userId, req.body))));
 }

--- a/src/dtos/zip.dto.js
+++ b/src/dtos/zip.dto.js
@@ -1,8 +1,8 @@
 
 // POST API DTO
-export const createZipReqDto = (body) => {
+export const createZipReqDto = (userId, body) => {
     return {
-        user_id : body.user_id,
+        user_id : userId,
         title : body.title,
         color : body.color,
     };
@@ -15,9 +15,9 @@ export const createZipResDto = (zip_id) => {
 };
 
 // DELETE API DTO
-export const deleteZipReqDto = (body) => {
+export const deleteZipReqDto = (userId, body) => {
     return {
-        user_id : body.user_id,
+        user_id : userId,
         zip_id : body.id,
         status : body.status
     };
@@ -41,9 +41,9 @@ export const getZipResDto = (zip) => {
 }
 
 // PATCH API DTO
-export const editZipReqDto = (body) => {
+export const editZipReqDto = (userId, body) => {
     return {
-        user_id : body.user_id,
+        user_id : userId,
         zip_id : body.id,
         title : body.title,
         color : body.color

--- a/src/models/link.dao.js
+++ b/src/models/link.dao.js
@@ -7,11 +7,11 @@ import { deleteLinkByIdSql, insertLinkSql, insertMemoLinkSql, insertMemoTextSql,
 /** 링크 호출 DAO - 모든 링크, 링크태그, 텍스트태그 */
 
 /** 링크 생성 DAO, 링크 id리턴 */
-export const addLinkDao = async (data) => {
+export const addLinkDao = async (userId, data) => {
     try {
-        const {zip_id, user_id, title, text, url, memo, alert_date} = data;
+        const {zip_id, title, text, url, memo, alert_date} = data;
         let sql;
-        let values = [zip_id, user_id, title, url, alert_date];
+        let values = [zip_id, userId, title, url, alert_date];
 
         if(memo != null && text != null){
             sql = insertMemoTextSql;

--- a/src/models/user.dao.js
+++ b/src/models/user.dao.js
@@ -33,6 +33,7 @@ export const getUserDao = async (userId) => {
         const conn = await pool.getConnection();
         const [[result]] = await conn.query(selectUserSql, userId);
         conn.release();
+        console.log(result);
         return result;
     } catch (error) {
         console.error(error);
@@ -45,6 +46,7 @@ export const getUserByKakaoIdDao = async (kakaoId) => {
         const conn = await pool.getConnection();
         const [[result]] = await conn.query(selectUserByKakaoIdSql, kakaoId);
         conn.release();
+        console.log(result);
         return result;
     } catch (error) {
         console.error(error);

--- a/src/models/user.dao.js
+++ b/src/models/user.dao.js
@@ -33,7 +33,6 @@ export const getUserDao = async (userId) => {
         const conn = await pool.getConnection();
         const [[result]] = await conn.query(selectUserSql, userId);
         conn.release();
-        console.log(result);
         return result;
     } catch (error) {
         console.error(error);
@@ -46,7 +45,6 @@ export const getUserByKakaoIdDao = async (kakaoId) => {
         const conn = await pool.getConnection();
         const [[result]] = await conn.query(selectUserByKakaoIdSql, kakaoId);
         conn.release();
-        console.log(result);
         return result;
     } catch (error) {
         console.error(error);

--- a/src/providers/list.provider.js
+++ b/src/providers/list.provider.js
@@ -2,8 +2,7 @@
 import { ListResponseDTO } from "@dtos/list.dto.js";
 import { getPreviewUnviewList, getPreviewLikeList, getPreviewRecentList } from "@models/list.dao.js";
 
-export const getUnviewList = async (req, query) => {
-    const userId = req.userId;
+export const getUnviewList = async (userId, query) => {
     let filter, sort;
     if( query === "undefined" || query === undefined || query === null){
         filter = null;
@@ -16,8 +15,7 @@ export const getUnviewList = async (req, query) => {
     return ListResponseDTO(await getPreviewUnviewList(userId , sort, filter));
 }
 
-export const getLikeList = async (req, query) => {
-    const userId = req.userId;
+export const getLikeList = async (userId, query) => {
     let filter, sort;
     if( query === "undefined" || query === undefined || query === null){
         filter = null;
@@ -30,8 +28,7 @@ export const getLikeList = async (req, query) => {
     return ListResponseDTO(await getPreviewLikeList(userId , sort, filter));
 }
 
-export const getRecentList = async (req, query) => {
-    const userId = req.userId;
+export const getRecentList = async (userId, query) => {
     let filter, sort;
     if( query === "undefined" || query === undefined || query === null){
         filter = null;

--- a/src/providers/zip.provider.js
+++ b/src/providers/zip.provider.js
@@ -2,5 +2,5 @@ import { getZipsDao } from "@models/zip.dao.js"
 import { getZipResDto } from "@dtos/zip.dto.js";
 
 export const getZipsProvider = async (req) => {
-    return (await getZipsDao(req.query.sort, req.body.user_id)).map((zip) => getZipResDto(zip));
+    return (await getZipsDao(req.query.sort, req.userId)).map((zip) => getZipResDto(zip));
 }

--- a/src/routes/link.route.js
+++ b/src/routes/link.route.js
@@ -8,8 +8,7 @@ export const linkRouter = express.Router();
 
 
 /** GET API */
-// user_id는 token에서 받아오는걸로 수정할 예정
-linkRouter.get("/get_links/:zip_id/:user_id", asyncHandler(getLinksCnt));
+linkRouter.get("/get_links/:zip_id", asyncHandler(getLinksCnt));
 linkRouter.get("/get_link/:link_id", asyncHandler(getLinkByIdCnt));
 
 

--- a/src/routes/list.route.js
+++ b/src/routes/list.route.js
@@ -6,8 +6,8 @@ import { viewUnviewList, viewLikeList, viewRecentList } from "../controllers/lis
 export const listRouter = express.Router();
 
 // 미열람 링크 조회
-listRouter.get('/unview/:userId', asyncHandler(viewUnviewList));
+listRouter.get('/unview', asyncHandler(viewUnviewList));
 // 좋아요 링크 조회
-listRouter.get('/like/:userId', asyncHandler(viewLikeList));
+listRouter.get('/like', asyncHandler(viewLikeList));
 // 최신저장 링크 조회
-listRouter.get('/recent/:userId', asyncHandler(viewRecentList));
+listRouter.get('/recent', asyncHandler(viewRecentList));

--- a/src/routes/user.route.js
+++ b/src/routes/user.route.js
@@ -4,8 +4,4 @@ import { kakaoLoginCnt, addUserCnt, getUserCnt, checkNicknameCnt } from '@contro
 
 export const userRouter = express.Router();
 
-userRouter.get("/:userId", asyncHandler(getUserCnt)); // 정보 조회
-userRouter.get("/", asyncHandler(checkNicknameCnt)); // 닉네임 중복 체크
-
-userRouter.post("/login", asyncHandler(kakaoLoginCnt)); // 카카오 로그인
-userRouter.post("/", asyncHandler(addUserCnt)); // 회원가입
+userRouter.get("/info", asyncHandler(getUserCnt)); // 정보 조회

--- a/src/services/alert.service.js
+++ b/src/services/alert.service.js
@@ -6,9 +6,10 @@ import {alertAddResponseDTO, alertPreviewResponseDTO, alertConfirmResponseDTO, a
 import {addAlert, getAlert, getLink,  getUserAlert, AlertConfirm, AlertDelete} from "../models/alert.dao.js";
 
 //알림 생성
-export const prepareAlertData = async (body) => {
+export const prepareAlertData = async (req) => {
+    const body = req.body;
     const AlertData = await addAlert({
-        'user_id': body.userId,
+        'user_id': req.userId,
         'link_id': body.linkId,
         'alert_date': body.alert_date,
         'alert_type': body.alert_type
@@ -21,8 +22,8 @@ export const prepareAlertData = async (body) => {
 }
 
 //알림 조회
-export const alertPreview= async (data) => {
-    const alerts = await getUserAlert(data.userId);
+export const alertPreview= async (req) => {
+    const alerts = await getUserAlert(req.userId);
     
     if (alerts==-1) {
         throw new BaseError(status.ALERT_NOT_FOUND); 

--- a/src/services/alert.service.js
+++ b/src/services/alert.service.js
@@ -1,15 +1,14 @@
 // alert.service.js
 
-import { BaseError } from "../../config/error.js";
-import { status } from "../../config/response.status.js";
-import {alertAddResponseDTO, alertPreviewResponseDTO, alertConfirmResponseDTO, alertDeleteResponseDTO } from "../dtos/alert.dto.js";
-import {addAlert, getAlert, getLink,  getUserAlert, AlertConfirm, AlertDelete} from "../models/alert.dao.js";
+import { BaseError } from "@config/error.js";
+import { status } from "@config/response.status.js";
+import { alertAddResponseDTO, alertPreviewResponseDTO, alertConfirmResponseDTO, alertDeleteResponseDTO } from "@dtos/alert.dto.js";
+import { addAlert, getAlert, getLink,  getUserAlert, AlertConfirm, AlertDelete } from "@models/alert.dao.js";
 
 //알림 생성
-export const prepareAlertData = async (req) => {
-    const body = req.body;
+export const prepareAlertData = async (userId, body) => {
     const AlertData = await addAlert({
-        'user_id': req.userId,
+        'user_id': userId,
         'link_id': body.linkId,
         'alert_date': body.alert_date,
         'alert_type': body.alert_type
@@ -22,8 +21,8 @@ export const prepareAlertData = async (req) => {
 }
 
 //알림 조회
-export const alertPreview= async (req) => {
-    const alerts = await getUserAlert(req.userId);
+export const alertPreview= async (userId) => {
+    const alerts = await getUserAlert(userId);
     
     if (alerts==-1) {
         throw new BaseError(status.ALERT_NOT_FOUND); 

--- a/src/services/link.service.js
+++ b/src/services/link.service.js
@@ -2,7 +2,7 @@ import { fetchUrlContent, getUrlThumb, getYoutubeSummary } from "@providers/link
 import { getGptResponse, getGptYoutubeSummary } from "@providers/link.provider";
 import { BaseError} from "@config/error";
 import { status } from "@config/response.status";
-import { addLinkDao, deleteZipIdDao, getLinkByIdDao, getLinksDao, updateLikeDao, updateThumbDao, updateVisitDao, updateZipIdDao } from "@models/link.dao";
+import { addLinkDao, deleteLinkByIdDao, getLinkByIdDao, getLinksDao, updateLikeDao, updateThumbDao, updateVisitDao, updateZipIdDao } from "@models/link.dao";
 import { createLinkResDto, deleteZipIdResDto, getLinkByIdResDto, getLinksResDto, updateLikeResDto, updateVisitResDto, updateZipIdResDto } from "@dtos/link.dto";
 
 /** 사이트 정보 요약 */
@@ -64,8 +64,8 @@ export const getLinkByIdSer = async (linkId) => {
     }
 }
 
-export const createNewLinkSer = async (body) => {
-    const createdLinkId = await addLinkDao(body); 
+export const createNewLinkSer = async (userId, body) => {
+    const createdLinkId = await addLinkDao(userId, body); 
     
     // provider를 통해 body.url의 thumb 주소값 가져옴
     const thumb = await getUrlThumb(body.url);   

--- a/src/services/user.service.js
+++ b/src/services/user.service.js
@@ -50,8 +50,7 @@ export const getUserByKakaoId = async (kakaoId) => {
 }
 
 /** 사용자 정보 조회 서비스 */
-export const getUserSer = async (req) => {
-    const userId = req.userId;
+export const getUserSer = async (userId) => {
     const result = await getUserDao(userId);
 
     if (result === undefined) {

--- a/swagger/alertCreate.swagger.yml
+++ b/swagger/alertCreate.swagger.yml
@@ -10,10 +10,6 @@ paths:
           required: true
           schema:
             properties:
-              userId:
-                type: integer
-                description: 유저 Id
-                example: 99
               linkId:
                 type: integer
                 description: 링크 Id

--- a/swagger/alertPreview.swagger.yml
+++ b/swagger/alertPreview.swagger.yml
@@ -4,12 +4,6 @@ paths:
       tags:
         - Alert
       summary: 알림 조회
-      parameters:
-        - name: userId
-          in: query
-          required: true
-          description: 유저 Id
-          example: 99
       responses:
         "200":
           description: 알림 생성 성공!

--- a/swagger/likelist.swagger.yml
+++ b/swagger/likelist.swagger.yml
@@ -1,15 +1,10 @@
 paths:
-  /list/like/{userId}:
+  /list/like:
     get:
       tags:
         - List
       summary: 사용자의 좋아요 링크 조회
       parameters:
-        - in: path
-          name: userId
-          required: true
-          type: integer
-          description: 사용자 Id
         - in: query
           name: sort
           type: string

--- a/swagger/link.swagger.yml
+++ b/swagger/link.swagger.yml
@@ -1,5 +1,5 @@
 paths:
-  /link/get_links/{zip_id}/{user_id}:
+  /link/get_links/{zip_id}:
     get:
       tags:
         - Link
@@ -15,13 +15,6 @@ paths:
           type: integer
           format: int32
           example: 1
-        - name: user_id
-          in: path
-          description: '사용자의 id값을 파라미터로 넘겨야 합니다.'
-          required: true
-          type: integer
-          format: int32
-          example: 123
         - name: tag
           in: query
           description: 'tag값이 link인 경우 link인 값들만 호출, text인 경우 text인 값들만 호출, 설정하지 않은 경우 모든 링크 데이터를 호출'
@@ -302,9 +295,6 @@ paths:
             type: object
             properties:
               zip_id:
-                type: integer
-                example: 99
-              user_id:
                 type: integer
                 example: 99
               title:

--- a/swagger/recentlist.swagger.yml
+++ b/swagger/recentlist.swagger.yml
@@ -1,15 +1,10 @@
 paths:
-  /list/recent/{userId}:
+  /list/recent:
     get:
       tags:
         - List
       summary: 사용자의 최근 저장한 링크 조회
       parameters:
-        - in: path
-          name: userId
-          required: true
-          type: integer
-          description: 사용자 Id
         - in: query
           name: sort
           type: string

--- a/swagger/unsightlist.swagger.yml
+++ b/swagger/unsightlist.swagger.yml
@@ -1,15 +1,10 @@
 paths:
-  /list/unview/{userId}:
+  /list/unview:
     get:
       tags:
         - List
       summary: 사용자의 미열람 링크 조회
       parameters:
-        - in: path
-          name: userId
-          required: true
-          type: integer
-          description: 사용자 Id
         - in: query
           name: sort
           type: string

--- a/swagger/user.swagger.yml
+++ b/swagger/user.swagger.yml
@@ -17,24 +17,32 @@ paths:
             properties:
               authCode: 
                 type: string
+                example: q1ozxUC1vZ0HI40oV2w6r1pIb8B6e2AdvEcaQoyz2a_BFT3KS2HSsQAAAAQKKiVQAAABkStXddZUdd9ffL_GXA
       responses:
         "200":
           description: 소셜 로그인 성공
           schema:
             type: object
             properties:
-              accessToken: 
+              isSuccess:
+                type: boolean
+                example: true
+              code:
+                example: 2000
+              message:
                 type: string
-              refreshToken: 
-                type: string
-        "400":
+                example: success!
+              result:
+                type: object
+                properties:
+                  accessToken:
+                    type: string
+                    example: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VySWQiOjEyMiwibmlja25hbWUiOiJzdHJpbmciLCJrYWthb0lkIjozNjQ2Mzk1ODU5LCJjb25uZWN0ZWRBdCI6IjIwMjQtMDgtMDFUMDQ6MzI6MjJaIiwiaWF0IjoxNzIzMDA5MDQ2LCJleHAiOjE3MjMwMTI2NDZ9.bCGW7EZH6fEcLS_KZD5UOVBfuVlbK2vWmLuRoriUn3o
+        "404":
           description: 소셜 로그인 실패
           schema:
             type: object
             properties:
-              status:
-                type: integer
-                example: 404
               isSuccess:
                 type: boolean
                 example: false
@@ -43,13 +51,7 @@ paths:
                 example: USER001
               message:
                 type: string
-                example: 해당 유저를 찾을 수 없습니다.
-              data:
-                type: object
-                example: 
-                  {
-                    "key": string
-                  }
+                example: 4ea5c508a6566e76240543f8feb06fd457777be39549c4016436afda65d2330e
         "500":
           description: 서버 에러
           schema:
@@ -87,9 +89,6 @@ paths:
           schema:
             type: object
             properties:
-              status:
-                type: integer
-                example: 200
               isSuccess:
                 type: boolean
                 example: true
@@ -99,14 +98,14 @@ paths:
               message:
                 type: string
                 example: 환상적인 닉네임이에요!
+              result:
+                type: boolean
+                example: true
         "400":
           description: 닉네임 중복
           schema:
             type: object
             properties:
-              status:
-                type: integer
-                example: 400
               isSuccess:
                 type: boolean
                 example: false
@@ -151,33 +150,41 @@ paths:
                 type: string
               key:
                 type: string
+                example: 4ea5c508a6566e76240543f8feb06fd457777be39549c4016436afda65d2330e
       responses:
         "200":
           description: 사용자 회원가입 성공
           schema:
             type: object
             properties:
-              accessToken: 
+              isSuccess:
+                type: boolean
+                example: true
+              code:
+                example: 2000
+              message:
                 type: string
-              refreshToken: 
-                type: string
+                example: success!
+              result:
+                type: object
+                properties:
+                  accessToken:
+                    type: string
+                    example: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VySWQiOjEyMiwibmlja25hbWUiOiJzdHJpbmciLCJrYWthb0lkIjozNjQ2Mzk1ODU5LCJjb25uZWN0ZWRBdCI6IjIwMjQtMDgtMDFUMDQ6MzI6MjJaIiwiaWF0IjoxNzIzMDA5MDQ2LCJleHAiOjE3MjMwMTI2NDZ9.bCGW7EZH6fEcLS_KZD5UOVBfuVlbK2vWmLuRoriUn3o
         "400":
           description: 잘못된 요청
           schema:
             type: object
             properties:
-              status:
-                type: integer
-                example: 400
               isSuccess:
                 type: boolean
                 example: false
               code:
                 type: integer
-                example: COMMON001
+                example: USER003
               message:
                 type: string
-                example: 잘못된 요청입니다
+                example: 유효하지 않은 키입니다.
         "500":
           description: 서버 에러
           schema:
@@ -195,18 +202,12 @@ paths:
               message:
                 type: string
                 example: 서버 에러, 관리자에게 문의 바랍니다.
-  /user/{userId}:
+  /user/info:
     get:
       tags:
         - User
       summary: 사용자 정보 조회
       description: 사용자 정보 조회를 위한 임시 API 입니다.
-      parameters:
-        - in: path
-          name: userId
-          required: true
-          type: integer
-          description: 사용자 Id
       responses:
         "200":
           description: 사용자 정보 조회 성공
@@ -217,6 +218,8 @@ paths:
                 type: integer
               nickname:
                 type: string
+              kakaoId:
+                type: integer
               createdAt:
                 type: string
         "400":


### PR DESCRIPTION
## 관련 이슈

- #40

## 요약 📝

- 인증 미들웨어 구성 및 userId 수정

## 상세 내용 🔥

- authMiddleware 구성
  - request header에서 authorization에 접근하여, 토큰의 유효성 검증 및 토큰의 userId를 추출합니다.
  - index.js에 해당 미들웨어를 삽입해, route를 통한 모든 요청에 의해 미들웨어가 동작하도록 했습니다.
  - 헤더 인증이 필요없는 api(로그인, 닉넴중복, 회원가입)는 index.js에 작성하여 미들웨어 검증에서 예외시켰습니다.
  - 스웨거에서 access token을 발급하여 헤더에 넣을 수 있습니다.
- userId가 필요한 api 수정
  - 최대한 로직을 건들지 않고, 되도록이면 controller에서 userId를 떼어 Service로 넘겨 처리했습니다.
  - 해당 과정에서 userId 파라미터가 추가된 함수가 일부 있습니다.
  - 알림 조회, zip 생성/조회, 링크 생성/조회 등 정상 작동 확인했습니다.

## 리뷰어에게 부탁, 유의사항 🙏

- access token 발급 및 설정 (현재 환경에서는 카카오 authcode를 받을 수 없어 발급이 불가능하므로 요청해주시면 accesstoken을 공유해드리겠습니다.)
- 로그인 진행 -> 성공(기존유저) 시 바로 발급, 실패(신규유저) 시 회원가입 용 key 발급
<img width="500" alt="image" src="https://github.com/user-attachments/assets/9202547d-05d9-4956-8c39-a2eba8526eab">
<img width="500" alt="image" src="https://github.com/user-attachments/assets/5818bcd8-0751-4df1-b057-10ed842492b5">

- 로그인 성공 또는 회원가입 성공 시 발급받는 access token을 스웨거 상단 Authorization에 설정
<img width="500" alt="image" src="https://github.com/user-attachments/assets/9508c8b7-68bd-46e8-a71d-625c2ba3d06e">
<img width="500" alt="image" src="https://github.com/user-attachments/assets/8105965c-222a-4913-a327-5f7b5fcae031">

- 커밋메시지 이슈연결을 40으로 안하고 33으로 한거를 지금 확인하고야 말았다는 점..흑흑
