### PR TITLE
[#47]Feat: URL 이미지, 제목 추출 기능 & 링크 수정 기능 추가

### DIFF
--- a/index.js
+++ b/index.js
@@ -38,7 +38,7 @@ app.post('/user', asyncHandler(addUserCnt)); // 회원가입
 app.use('/api-docs', SwaggerUi.serve, SwaggerUi.setup(specs));
 
 // 모든 route에 대해 검증 미들웨어 적용
-app.use(tokenAuthMiddleware);
+// app.use(tokenAuthMiddleware);
 
 // router setting
 app.use('/list', listRouter);

--- a/index.js
+++ b/index.js
@@ -38,7 +38,7 @@ app.post('/user', asyncHandler(addUserCnt)); // 회원가입
 app.use('/api-docs', SwaggerUi.serve, SwaggerUi.setup(specs));
 
 // 모든 route에 대해 검증 미들웨어 적용
-// app.use(tokenAuthMiddleware);
+app.use(tokenAuthMiddleware);
 
 // router setting
 app.use('/list', listRouter);

--- a/src/controllers/link.controller.js
+++ b/src/controllers/link.controller.js
@@ -1,7 +1,7 @@
 import { response } from "@config/response";
 import { status } from "@config/response.status";
 import { BaseError } from "@config/error";
-import { createNewLinkSer, deleteLinkByIdSer, generateUrlSummary, getLinkByIdSer, getLinksSer, updateLikeSer, updateVisitSer, updateZipIdSer } from "@services/link.service";
+import { createNewLinkSer, deleteLinkByIdSer, extractUrlSer, generateUrlSummary, getLinkByIdSer, getLinksSer, modifyLinkSer, updateLikeSer, updateVisitSer, updateZipIdSer } from "@services/link.service";
 
 
 export const getLinksCnt = async (req, res) => {
@@ -26,10 +26,10 @@ export const getLinkByIdCnt = async (req, res) => {
     }
 }
 
-export const getSummaryCnt = async (req,res) => {
+export const getSummaryCnt = async (req, res) => {
     const url = req.body.url;
 
-    if (!url) { // 에러 메시지 추후 수정
+    if (!url) {
         return BaseError(status.BAD_REQUEST);
     }
 
@@ -39,6 +39,22 @@ export const getSummaryCnt = async (req,res) => {
     } catch (err) {
         return BaseError(status.FETCH_FAIL);
     }
+}
+
+export const extractUrlCnt = async (req, res) => {
+    const url = req.body.url;
+
+    if (!url) {
+        return BaseError(status.BAD_REQUEST);
+    }
+
+    try {
+        const extractResponse = await extractUrlSer(url);
+        res.send(response(status.SUCCESS, extractResponse));
+    } catch (err){
+        return BaseError(status.FETCH_FAIL);
+    }
+
 }
 
 export const createNewLinkCnt = async (req, res) => {
@@ -76,6 +92,14 @@ export const updateZipIdCnt = async (req, res) => {
     }
 }
 
+export const modifyLinkCnt = async (req, res) => {
+    try {
+        const {link_id} = req.params;
+        res.send(response(status.SUCCESS, await modifyLinkSer(link_id, req.body)));
+    } catch (err) {
+        return BaseError(status.FAILED_TO_UPDATE);
+    }
+}
 
 export const deleteLinkByIdCnt = async (req, res) => {
     try {

--- a/src/dtos/link.dto.js
+++ b/src/dtos/link.dto.js
@@ -5,6 +5,13 @@ export const createLinkResDto = (linkId) => {
     };
 }
 
+export const extractUrlResDto = (thumb, title) => {
+    return {
+        thumb,
+        title
+    }
+}
+
 export const getLinksResDto = (getResult) => {
     return getResult.map(({ id, zip_id, user_id, title, url, text, memo, tag, alert_date, thumb, like, visit, visit_date, created_at, updated_at }) => ({
         id,
@@ -26,10 +33,11 @@ export const getLinksResDto = (getResult) => {
 }
 
 
-export const getLinkByIdResDto = ({id, title, memo, text, alert_date, like, visit}) => {
+export const getLinkByIdResDto = ({id, title, memo, text,thumb, alert_date, like, visit}) => {
     return {
         id,
         title,
+        thumb,
         memo,
         text,
         alert_date,
@@ -61,6 +69,16 @@ export const updateZipIdResDto = (updateResult) => {
         link_id: updateResult.id ,
         new_zip_id: updateResult.zip_id,
         message: `zip이동을 완료하였습니다. 새로 이동한 zip id는 ${updateResult.zip_id}입니다.`
+    }
+}
+
+export const modifyLinkResDto = ({id, title, text, memo, alert_date}) => {
+    return {
+        title, 
+        text, 
+        memo, 
+        alert_date,
+        message: `${id}번 링크 내용을 성공적으로 수정하였습니다.`
     }
 }
 

--- a/src/models/link.sql.js
+++ b/src/models/link.sql.js
@@ -34,5 +34,15 @@ export const updateZipIdSql = "UPDATE link SET zip_id = ? WHERE id = ?";
 
 export const selectUpdatedZipIdSql = "SELECT id, zip_id FROM link WHERE id = ?"
 
+/** UPDATE LINK */
+export const updateTextMemoLinkSql = "UPDATE link SET title = ?, text = ?, memo = ?, alert_date = ? WHERE id = ?;";
+
+export const updateTextLinkSql = "UPDATE link SET title = ?, text = ?, alert_date = ? WHERE id = ?;";
+
+export const updateMemoLinkSql = "UPDATE link SET title = ?, memo = ?, alert_date = ? WHERE id = ?;";
+
+export const updateLinkSql = "UPDATE link SET title = ?, alert_date = ? WHERE id = ?;";
+
+
 /** DELETE LINK BY ID */
 export const deleteLinkByIdSql = "DELETE FROM link WHERE id = ?";

--- a/src/providers/link.provider.js
+++ b/src/providers/link.provider.js
@@ -87,10 +87,26 @@ export const getUrlThumb = async (url) => {
         const $ = cheerio.load(data);
         const ogImage = $('meta[property="og:image"]').attr('content');
 
-        console.log('thumb 추출 내용:', ogImage);
         return ogImage || null; //og:image가 없는 경우 null반환
     } catch (err) {
         console.log(err);
         return null; //url이 실제로 접속 불가능한 url이어도 에러 처리하지 않도록
     }
 }
+
+export const getUrlTitle = async (url) => {
+    if (!url) {
+        return null;
+    }
+
+    try {
+        const { data } = await axios.get(url);
+        const $ = cheerio.load(data);
+        const title = $('title').text();
+
+        return title || null; // 제목이 없는 경우 null 반환
+    } catch (err) {
+        console.log(err);
+        return null; // url이 실제로 접속 불가능한 url이어도 에러 처리하지 않도록
+    }
+};

--- a/src/routes/link.route.js
+++ b/src/routes/link.route.js
@@ -1,7 +1,7 @@
 // src/routes/list.route.js
 import express from 'express';
 import asyncHandler from 'express-async-handler';
-import { getLinksCnt, createNewLinkCnt, getSummaryCnt, updateVisitCnt, updateLikeCnt, updateZipIdCnt, deleteLinkByIdCnt, getLinkByIdCnt } from '@controllers/link.controller';
+import { getLinksCnt, createNewLinkCnt, getSummaryCnt, updateVisitCnt, updateLikeCnt, updateZipIdCnt, deleteLinkByIdCnt, getLinkByIdCnt, extractUrlCnt, modifyLinkCnt } from '@controllers/link.controller';
 //controller
 
 export const linkRouter = express.Router();
@@ -16,12 +16,13 @@ linkRouter.get("/get_link/:link_id", asyncHandler(getLinkByIdCnt));
 /** POST API */
 linkRouter.post('/summary', asyncHandler(getSummaryCnt)); // 텍스트 요약(url전송)
 linkRouter.post('/add', asyncHandler(createNewLinkCnt)); 
-
+linkRouter.post('/extract', asyncHandler(extractUrlCnt));
 
 /** PATCH API */
 linkRouter.patch('/visit/:link_id', asyncHandler(updateVisitCnt));
 linkRouter.patch('/update_like/:link_id', asyncHandler(updateLikeCnt));
 linkRouter.patch('/move/:link_id/:new_zip_id', asyncHandler(updateZipIdCnt));
+linkRouter.patch('/modify/:link_id', asyncHandler(modifyLinkCnt));
 
 /** DELETE API */
 linkRouter.delete('/delete/:link_id', asyncHandler(deleteLinkByIdCnt));

--- a/src/services/link.service.js
+++ b/src/services/link.service.js
@@ -1,9 +1,9 @@
-import { fetchUrlContent, getUrlThumb, getYoutubeSummary } from "@providers/link.provider";
+import { fetchUrlContent, getUrlThumb, getUrlTitle, getYoutubeSummary } from "@providers/link.provider";
 import { getGptResponse, getGptYoutubeSummary } from "@providers/link.provider";
 import { BaseError} from "@config/error";
 import { status } from "@config/response.status";
-import { addLinkDao, deleteLinkByIdDao, getLinkByIdDao, getLinksDao, updateLikeDao, updateThumbDao, updateVisitDao, updateZipIdDao } from "@models/link.dao";
-import { createLinkResDto, deleteZipIdResDto, getLinkByIdResDto, getLinksResDto, updateLikeResDto, updateVisitResDto, updateZipIdResDto } from "@dtos/link.dto";
+import { addLinkDao, deleteLinkByIdDao, getLinkByIdDao, getLinksDao, modifyLinkDao, updateLikeDao, updateThumbDao, updateVisitDao, updateZipIdDao } from "@models/link.dao";
+import { createLinkResDto, deleteZipIdResDto, extractUrlResDto, getLinkByIdResDto, getLinksResDto, modifyLinkResDto, updateLikeResDto, updateVisitResDto, updateZipIdResDto } from "@dtos/link.dto";
 
 /** 사이트 정보 요약 */
 export const summarizeContent = async (content, maxLength = 1000) => {
@@ -20,6 +20,13 @@ export const summarizeContent = async (content, maxLength = 1000) => {
 export const checkYoutube = (url) => {
     if (url.includes('youtube.com/watch?v=') || url.includes('youtu.be/'))
         return true;
+}
+
+export const extractUrlSer = async (url) => {
+    const thumb = await getUrlThumb(url);
+    const title = await getUrlTitle(url);
+
+    return extractUrlResDto(thumb, title);
 }
 
 /** url 요약 정보 생성 */
@@ -90,6 +97,8 @@ export const updateVisitSer = async (linkId) => {
 
     if(updateVisitResult == null){
         throw new BaseError(status.FAILED_TO_UPDATE);
+    } else if(typeof updateVisitResult === 'string') {
+        return updateVisitResult;
     } else {
         return updateVisitResDto(updateVisitResult);
     }
@@ -110,6 +119,17 @@ export const updateZipIdSer = async (linkId, newZipId) => {
         throw new BaseError(status.FAILED_TO_UPDATE);
     } else {
         return updateZipIdResDto(updateZipIdResult);
+    }
+}
+
+export const modifyLinkSer = async (linkId, body) => {
+    const modifyLinkResult = await modifyLinkDao(linkId, body);
+    if(modifyLinkResult == null) {
+        throw new BaseError(status.FAILED_TO_UPDATE);
+    } else if(typeof modifyLinkResult === 'string'){
+        return modifyLinkResult;
+    } else {
+        return modifyLinkResDto(modifyLinkResult);
     }
 }
 

--- a/swagger/link.swagger.yml
+++ b/swagger/link.swagger.yml
@@ -12,57 +12,71 @@ paths:
           in: path
           description: '링크가 속한 zip의 id값을 파라미터로 넘겨야 합니다.'
           required: true
-          type: integer
-          format: int32
-          example: 1
+          schema:
+            type: integer
+            format: int32
+            example: 1
         - name: tag
           in: query
           description: 'tag값이 link인 경우 link인 값들만 호출, text인 경우 text인 값들만 호출, 설정하지 않은 경우 모든 링크 데이터를 호출'
           required: false
-          type: string
-          example: 'link'
+          schema:
+            type: string
+            example: 'link'
       responses:
         200:
           description: 링크 데이터가 성공적으로 호출된 경우
           schema:
-            type: array
-            items:
-              type: object
-              properties:
-                id:
-                  type: integer
-                zip_id:
-                  type: integer
-                user_id:
-                  type: integer
-                title:
-                  type: string
-                url:
-                  type: string
-                text:
-                  type: string
-                memo:
-                  type: string
-                tag:
-                  type: string
-                alert_date:
-                  type: string
-                  format: date-time
-                thumb:
-                  type: string
-                like:
-                  type: integer
-                visit:
-                  type: integer
-                visit_date:
-                  type: string
-                  format: date-time
-                created_at:
-                  type: string
-                  format: date-time
-                updated_at:
-                  type: string
-                  format: date-time
+            type: object
+            properties:
+              isSuccess:
+                type: boolean
+                example: true
+              code:
+                type: integer
+                example: 2000
+              message:
+                type: string
+                example: "success!"
+              result:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    id:
+                      type: integer
+                    zip_id:
+                      type: integer
+                    user_id:
+                      type: integer
+                    title:
+                      type: string
+                    url:
+                      type: string
+                    text:
+                      type: string
+                    memo:
+                      type: string
+                    tag:
+                      type: string
+                    alert_date:
+                      type: string
+                      format: date-time
+                    thumb:
+                      type: string
+                    like:
+                      type: integer
+                    visit:
+                      type: integer
+                    visit_date:
+                      type: string
+                      format: date-time
+                    created_at:
+                      type: string
+                      format: date-time
+                    updated_at:
+                      type: string
+                      format: date-time
         400:
           description: 잘못된 요청
           schema:
@@ -97,6 +111,7 @@ paths:
               message:
                 type: string
                 example: "서버 에러, 관리자에게 문의 바랍니다."
+              
   /link/get_link/{link_id}:
     get:
       tags:
@@ -110,49 +125,62 @@ paths:
           in: path
           description: '링크 ID 값을 경로 매개변수로 전달합니다.'
           required: true
-          type: integer
-          format: int32
-          example: 1
+          schema:
+            type: integer
+            format: int32
+            example: 1
       responses:
         200:
           description: 링크 데이터가 성공적으로 호출된 경우
           schema:
             type: object
             properties:
-              id:
+              isSuccess:
+                type: boolean
+                example: true
+              code:
                 type: integer
-              zip_id:
-                type: integer
-              user_id:
-                type: integer
-              title:
+                example: 2000
+              message:
                 type: string
-              url:
-                type: string
-              text:
-                type: string
-              memo:
-                type: string
-              tag:
-                type: string
-              alert_date:
-                type: string
-                format: date-time
-              thumb:
-                type: string
-              like:
-                type: integer
-              visit:
-                type: integer
-              visit_date:
-                type: string
-                format: date-time
-              created_at:
-                type: string
-                format: date-time
-              updated_at:
-                type: string
-                format: date-time
+                example: "success!"
+              result:
+                type: object
+                properties:
+                  id:
+                    type: integer
+                  zip_id:
+                    type: integer
+                  user_id:
+                    type: integer
+                  title:
+                    type: string
+                  url:
+                    type: string
+                  text:
+                    type: string
+                  memo:
+                    type: string
+                  tag:
+                    type: string
+                  alert_date:
+                    type: string
+                    format: date-time
+                  thumb:
+                    type: string
+                  like:
+                    type: integer
+                  visit:
+                    type: integer
+                  visit_date:
+                    type: string
+                    format: date-time
+                  created_at:
+                    type: string
+                    format: date-time
+                  updated_at:
+                    type: string
+                    format: date-time
         400:
           description: 잘못된 요청
           schema:
@@ -175,9 +203,6 @@ paths:
           schema:
             type: object
             properties:
-              status:
-                type: integer
-                example: 404
               isSuccess:
                 type: boolean
                 example: false
@@ -204,86 +229,12 @@ paths:
               message:
                 type: string
                 example: "서버 에러, 관리자에게 문의 바랍니다."
-  /link/summary:
-    post:
-      tags:
-        - Link
-      summary: url의 정보 추출 및 AI 요약
-      consumes:
-        - application/json
-      parameters:
-        - in: body
-          name: body
-          description: url 정보를 AI에게 요약받기 위한 요청 양식
-          required: true
-          schema:
-            type: object
-            properties:
-              url:
-                type: string
-                example: https://www.example.com
 
-      responses:
-        200:
-          description: AI의 응답을 성공적으로 받아왔습니다.
-          schema:
-            type: object
-            properties:
-              isSuccess:
-                type: boolean
-                example: true
-              code:
-                type: integer
-                example: 2000
-              message:
-                type: string
-                example: "success!"
-              result:
-                type: object
-                properties:
-                  summary:
-                    type: string
-                    example: "This is a summary of the content at the given URL."
-        400:
-          description: 잘못된 요청
-          schema:
-            type: object
-            properties:
-              status:
-                type: integer
-                example: 400
-              isSuccess:
-                type: boolean
-                example: false
-              code:
-                type: integer
-                example: COMMON001
-              message:
-                type: string
-                example: 잘못된 요청입니다
-        500:
-          description: 서버 에러
-          schema:
-            type: object
-            properties:
-              status:
-                type: integer
-                example: 500
-              isSuccess:
-                type: boolean
-                example: false
-              code:
-                type: integer
-                example: COMMON000
-              message:
-                type: string
-                example: 서버 에러, 관리자에게 문의 바랍니다.
-  
   /link/add:
     post:
       tags:
         - Link
-      summary: link 데이터(text포함) 추가 생성
+      summary: link 데이터(text 포함) 추가 생성
       consumes:
         - application/json
       parameters:
@@ -329,8 +280,86 @@ paths:
                 type: string
                 example: "create success!"
               result:
+                type: object
+                properties:
+                  link_id:
+                    type: integer
+                    example: 123
+        400:
+          description: 잘못된 요청
+          schema:
+            type: object
+            properties:
+              isSuccess:
+                type: boolean
+                example: false
+              code:
+                type: integer
+                example: COMMON001
+              message:
                 type: string
-                example: "생성된 링크 id: 123"
+                example: "잘못된 요청입니다"
+              result:
+                type: object
+                additionalProperties: false
+        500:
+          description: 서버 에러
+          schema:
+            type: object
+            properties:
+              isSuccess:
+                type: boolean
+                example: false
+              code:
+                type: integer
+                example: COMMON000
+              message:
+                type: string
+                example: "서버 에러, 관리자에게 문의 바랍니다."
+              result:
+                type: object
+                additionalProperties: false
+
+
+  /link/visit/{link_id}:
+    patch:
+      tags:
+        - Link
+      summary: 링크 방문 수 및 방문 날짜 업데이트
+      parameters:
+        - name: link_id
+          in: path
+          description: '방문 수를 업데이트할 링크의 ID'
+          required: true
+          schema:
+            type: integer
+            format: int32
+            example: 1
+      responses:
+        200:
+          description: 방문 수 및 방문 날짜가 성공적으로 업데이트된 경우
+          schema:
+            type: object
+            properties:
+              isSuccess:
+                type: boolean
+                example: true
+              code:
+                type: integer
+                example: 2000
+              message:
+                type: string
+                example: "success!"
+              result:
+                type: object
+                properties:
+                  link_id:
+                    type: integer
+                  visit:
+                    type: integer
+                  visit_date:
+                    type: string
+                    format: date-time
         400:
           description: 잘못된 요청
           schema:
@@ -365,36 +394,6 @@ paths:
               message:
                 type: string
                 example: "서버 에러, 관리자에게 문의 바랍니다."
-  /link/visit/{link_id}:
-    patch:
-      tags:
-        - Link
-      summary: 링크 방문 수 및 방문 날짜 업데이트
-      parameters:
-        - name: link_id
-          in: path
-          description: '방문 수를 업데이트할 링크의 ID'
-          required: true
-          type: integer
-          format: int32
-          example: 1
-      responses:
-        200:
-          description: 방문 수 및 방문 날짜가 성공적으로 업데이트된 경우
-          schema:
-            type: object
-            properties:
-              link_id:
-                type: integer
-              visit:
-                type: integer
-              visit_date:
-                type: string
-                format: date-time
-        400:
-          description: 잘못된 요청
-        500:
-          description: 서버 에러
 
   /link/update_like/{link_id}:
     patch:
@@ -406,23 +405,66 @@ paths:
           in: path
           description: '좋아요 상태를 업데이트할 링크의 ID'
           required: true
-          type: integer
-          format: int32
-          example: 1
+          schema:
+            type: integer
+            format: int32
+            example: 1
       responses:
         200:
           description: 좋아요 상태가 성공적으로 업데이트된 경우
           schema:
             type: object
             properties:
-              link_id:
+              isSuccess:
+                type: boolean
+                example: true
+              code:
                 type: integer
-              like:
-                type: integer
+                example: 2000
+              message:
+                type: string
+                example: "success!"
+              result:
+                type: object
+                properties:
+                  link_id:
+                    type: integer
+                  like:
+                    type: integer
         400:
           description: 잘못된 요청
+          schema:
+            type: object
+            properties:
+              status:
+                type: integer
+                example: 400
+              isSuccess:
+                type: boolean
+                example: false
+              code:
+                type: integer
+                example: COMMON001
+              message:
+                type: string
+                example: "잘못된 요청입니다"
         500:
           description: 서버 에러
+          schema:
+            type: object
+            properties:
+              status:
+                type: integer
+                example: 500
+              isSuccess:
+                type: boolean
+                example: false
+              code:
+                type: integer
+                example: COMMON000
+              message:
+                type: string
+                example: "서버 에러, 관리자에게 문의 바랍니다."
 
   /link/move/{link_id}/{new_zip_id}:
     patch:
@@ -434,30 +476,192 @@ paths:
           in: path
           description: 'Zip을 이동할 링크의 ID'
           required: true
-          type: integer
-          format: int32
-          example: 1
+          schema:
+            type: integer
+            format: int32
+            example: 1
         - name: new_zip_id
           in: path
           description: '이동할 Zip의 ID'
           required: true
-          type: integer
-          format: int32
-          example: 2
+          schema:
+            type: integer
+            format: int32
+            example: 2
       responses:
         200:
           description: Zip이 성공적으로 업데이트된 경우
           schema:
             type: object
             properties:
-              link_id:
+              isSuccess:
+                type: boolean
+                example: true
+              code:
                 type: integer
-              new_zip_id:
-                type: integer
+                example: 2000
+              message:
+                type: string
+                example: "success!"
+              result:
+                type: object
+                properties:
+                  link_id:
+                    type: integer
+                  new_zip_id:
+                    type: integer
         400:
           description: 잘못된 요청
+          schema:
+            type: object
+            properties:
+              status:
+                type: integer
+                example: 400
+              isSuccess:
+                type: boolean
+                example: false
+              code:
+                type: integer
+                example: COMMON001
+              message:
+                type: string
+                example: "잘못된 요청입니다"
         500:
           description: 서버 에러
+          schema:
+            type: object
+            properties:
+              status:
+                type: integer
+                example: 500
+              isSuccess:
+                type: boolean
+                example: false
+              code:
+                type: integer
+                example: COMMON000
+              message:
+                type: string
+                example: "서버 에러, 관리자에게 문의 바랍니다."
+
+  /link/modify/{link_id}:
+    patch:
+      tags:
+        - Link
+      summary: 링크 지정하여 내용 수정
+      consumes:
+        - application/json
+      parameters:
+        - in: path
+          name: link_id
+          description: 수정할 링크의 ID
+          required: true
+          schema:
+            type: integer
+            example: 123
+        - in: body
+          name: body
+          description: 수정할 링크의 제목, 텍스트, 메모, 알림 날짜 등의 정보를 포함합니다.
+          required: true
+          schema:
+            type: object
+            properties:
+              title:
+                type: string
+                example: "Updated Title"
+              text:
+                type: string
+                example: "Updated Text Content"
+              memo:
+                type: string
+                example: "Updated Memo"
+              alert_date:
+                type: string
+                format: date
+                example: "2024-08-15"
+      responses:
+        200:
+          description: 링크 정보를 성공적으로 수정했습니다.
+          schema:
+            type: object
+            properties:
+              isSuccess:
+                type: boolean
+                example: true
+              code:
+                type: integer
+                example: 2000
+              message:
+                type: string
+                example: "success!"
+              result:
+                type: object
+                properties:
+                  title:
+                    type: string
+                    example: "Updated Title"
+                  text:
+                    type: string
+                    example: "Updated Text Content"
+                  memo:
+                    type: string
+                    example: "Updated Memo"
+                  alert_date:
+                    type: string
+                    format: date
+                    example: "2024-08-15"
+                  message:
+                    type: string
+                    example: "123번 링크 내용을 성공적으로 수정하였습니다."
+        400:
+          description: 잘못된 요청입니다.
+          schema:
+            type: object
+            properties:
+              status:
+                type: integer
+                example: 400
+              isSuccess:
+                type: boolean
+                example: false
+              code:
+                type: integer
+                example: COMMON001
+              message:
+                type: string
+                example: "잘못된 요청입니다."
+        404:
+          description: 수정할 링크를 찾을 수 없습니다.
+          schema:
+            type: object
+            properties:
+              isSuccess:
+                type: boolean
+                example: false
+              code:
+                type: integer
+                example: NOT_FOUND
+              message:
+                type: string
+                example: "수정된 링크 데이터가 없습니다."
+        500:
+          description: 서버 에러입니다.
+          schema:
+            type: object
+            properties:
+              status:
+                type: integer
+                example: 500
+              isSuccess:
+                type: boolean
+                example: false
+              code:
+                type: integer
+                example: COMMON000
+              message:
+                type: string
+                example: "서버 에러, 관리자에게 문의 바랍니다."
 
   /link/delete/{link_id}:
     delete:
@@ -469,19 +673,62 @@ paths:
           in: path
           description: '삭제할 링크의 ID'
           required: true
-          type: integer
-          format: int32
-          example: 1
+          schema:
+            type: integer
+            format: int32
+            example: 1
       responses:
         200:
           description: 링크가 성공적으로 삭제된 경우
           schema:
-            type: string
-            example: "1개의 링크 데이터를 성공적으로 삭제하였습니다."
+            type: object
+            properties:
+              isSuccess:
+                type: boolean
+                example: true
+              code:
+                type: integer
+                example: 2000
+              message:
+                type: string
+                example: "success!"
+              result:
+                type: object
+                properties:
+                  message:
+                    type: string
+                    example: "1개의 링크 데이터를 성공적으로 삭제하였습니다."
         400:
           description: 잘못된 요청
+          schema:
+            type: object
+            properties:
+              status:
+                type: integer
+                example: 400
+              isSuccess:
+                type: boolean
+                example: false
+              code:
+                type: integer
+                example: COMMON001
+              message:
+                type: string
+                example: "잘못된 요청입니다."
         500:
           description: 서버 에러
-
-
-        
+          schema:
+            type: object
+            properties:
+              status:
+                type: integer
+                example: 500
+              isSuccess:
+                type: boolean
+                example: false
+              code:
+                type: integer
+                example: COMMON000
+              message:
+                type: string
+                example: "서버 에러, 관리자에게 문의 바랍니다."


### PR DESCRIPTION
## 관련 이슈

- #47 

## 요약 📝

- 프론트 팀장님과 소통하여 필요한 추가 링크 기능을 구현하였습니다.

## 상세 내용 🔥

- 새로운 링크를 생성할 때, 최종 저장 요청 필드를 받기 전, url만 입력하고 추천 제목 및 미리보기 이미지 값을 프론트에 넘겨줘야 하는 로직이라서, url을 입력하면 미리보기 이미지와 제목을 추출하여 전달하는 기능을 구현하였습니다.
- 링크 수정은 보류중이었으나, 기존의 페이지를 재활용하여 프론트 화면은 구현이 가능한 듯 하여 수정 기능을 구현하였습니다.
- swagger 문서 응답 형식을 통일하였습니다.

## 리뷰어에게 부탁, 유의사항 🙏

- 
