### PR TITLE
[#50] Refactor: 카카오 로그인 수정 및 Bearer 설정

### DIFF
--- a/config/authMiddleware.js
+++ b/config/authMiddleware.js
@@ -8,8 +8,10 @@ export const tokenAuthMiddleware = (req, res, next) => {
     if (!header) {
         throw new BaseError(status.TOKEN_INVALID);
     }
-
-    const token = header.split('Bearer ')[1];
+    let token = header;
+    if (header.startsWith('Bearer ')) {
+        token = header.split('Bearer ')[1];
+    }
 
     jwt.verify(token, process.env.JWT_SECRET, (err, decoded) => {
         if (err) {

--- a/config/authMiddleware.js
+++ b/config/authMiddleware.js
@@ -4,10 +4,12 @@ import { BaseError } from './error.js';
 
 /** 토큰 검증 미들웨어, req.userId 반환 */
 export const tokenAuthMiddleware = (req, res, next) => {
-    const token = req.headers['authorization'] || req.headers['Authorization'];
-    if (!token) {
+    const header = req.headers['authorization'] || req.headers['Authorization'];
+    if (!header) {
         throw new BaseError(status.TOKEN_INVALID);
     }
+
+    const token = header.split('Bearer ')[1];
 
     jwt.verify(token, process.env.JWT_SECRET, (err, decoded) => {
         if (err) {

--- a/index.js
+++ b/index.js
@@ -19,7 +19,7 @@ import { zipRouter } from '@routes/zip.route.js'
 import { noticeRouter } from '@routes/notice.route';
 import { searchRouter } from '@routes/search.route';
 
-import { addUserCnt, checkNicknameCnt, kakaoLoginCnt } from '@controllers/user.controller';
+import { addUserCnt, checkNicknameCnt, getTestTokenCnt, kakaoLoginCnt } from '@controllers/user.controller';
 
 dotenv.config();
 
@@ -36,6 +36,7 @@ app.use(express.urlencoded({extended: true})); // 단순 객체 문자열 형태
 app.post('/user/login', asyncHandler(kakaoLoginCnt)); // 로그인
 app.get('/user', asyncHandler(checkNicknameCnt)); // 닉네임 중복 체크
 app.post('/user', asyncHandler(addUserCnt)); // 회원가입
+app.post('/user/token/test', asyncHandler(getTestTokenCnt)); // 테스트용 토큰 발급
 app.use('/api-docs', SwaggerUi.serve, SwaggerUi.setup(specs));
 
 // 모든 route에 대해 검증 미들웨어 적용

--- a/src/controllers/user.controller.js
+++ b/src/controllers/user.controller.js
@@ -7,8 +7,27 @@ import { getKakaoUserInfo } from "@providers/user.provider.js";
 
 /** 카카오 로그인 및 jwt 생성 */
 export const kakaoLoginCnt = async (req, res, next) => {
-    const { authCode } = req.body;
-    const kakaoUserInfo = await getKakaoUserInfo(authCode); // authCode로 카카오 토큰 발급
+    // const { authCode } = req.body;
+    // const kakaoUserInfo = await getKakaoUserInfo(authCode); // authCode로 카카오 토큰 발급
+
+    const { accessToken, accessTokenExpires, refreshToken, refreshTokenExpires } = req.body;
+    const kakaoUserInfo = await getKakaoUserInfo(accessToken);
+    
+    /** TODO : 카카오 토큰 갱신 로직 */
+    // try {
+    //     kakaoUserInfo = await getKakaoUserInfo(accessToken); // 카카오 토큰으로 카카오 유저 정보 조회
+    //     console.log(kakaoUserInfo);
+    // } catch (error) {
+    //     if (error.response.status === 401) {
+    //         try {
+    //             const newTokens = await refreshKakaoToken(refreshToken);
+    //             kakaoUserInfo = await getKakaoUserInfo(newTokens.accessToken);
+    //         } catch (error) {
+    //             throw new BaseError(status.KAKAO_TOKEN_ERROR);
+    //         }
+    //     }
+    // }
+
     const result = await getUserByKakaoId(kakaoUserInfo.id); // 신규 유저일 시 여기서 throw
 
     const payload = {

--- a/src/controllers/user.controller.js
+++ b/src/controllers/user.controller.js
@@ -82,3 +82,21 @@ export const checkNicknameCnt = async (req, res, next) => {
 
     return res.send(response(status.NICKNAME_VALID, await checkNicknameSer(nickname)));
 }
+
+export const getTestTokenCnt = async (req, res, next) => {
+    const result = await getUserSer(99);
+
+    const payload = {
+        userId: result.userId,
+        nickname: result.nickname,
+        kakaoId: result.kakaoId,
+        connectedAt: result.createdAt,
+    };
+
+    try {
+        const token = jwt.sign(payload, process.env.JWT_SECRET, { expiresIn: '1h' });
+        res.send(response(status.SUCCESS, {accessToken: token}));
+    } catch (error) {
+        throw new BaseError(status.SERVER_TOKEN_ERROR); // jwt 발급 실패시
+    }
+}

--- a/src/providers/user.provider.js
+++ b/src/providers/user.provider.js
@@ -4,7 +4,7 @@ import { status } from "@config/response.status";
 import { BaseError } from "@config/error";
 
 /** 카카오 토큰 발급 */
-export const getKakaoUserInfo = async (authCode) => {
+export const getKakaoToken = async (authCode) => {
     try {
         const tokenResponse = await axios.post(
             `https://kauth.kakao.com/oauth/token`, null,
@@ -25,6 +25,24 @@ export const getKakaoUserInfo = async (authCode) => {
             {
                 headers: {
                     Authorization: `Bearer ${accessToken}`,
+                },
+            }
+        );
+    
+        return userInfoResponse.data;
+    } catch (error) {
+        throw new BaseError(status.KAKAO_TOKEN_ERROR);
+    }
+}
+
+/** 카카오 토큰으로 유저 정보 추출 */
+export const getKakaoUserInfo = async (kakaoToken) => {
+    try {
+        const userInfoResponse = await axios.get(
+            `https://kapi.kakao.com/v2/user/me`,
+            {
+                headers: {
+                    Authorization: `Bearer ${kakaoToken}`,
                 },
             }
         );

--- a/swagger/user.swagger.yml
+++ b/swagger/user.swagger.yml
@@ -5,19 +5,24 @@ paths:
         - User
       summary: 소셜 로그인
       description: | 
-        카카오 authCode를 받아 소셜 로그인을 진행합니다. 
+        카카오 access token을 받아 소셜 로그인을 진행합니다. 
         기존 유저라면 토큰을 반환하며, 신규 유저라면 회원가입을 위한 key를 반환합니다.
       parameters:
         - in: body
           name: body
-          description: 카카오 authCode
+          description: 카카오 access token
           required: true
           schema:
             type: object
             properties:
-              authCode: 
+              accessToken: 
                 type: string
-                example: q1ozxUC1vZ0HI40oV2w6r1pIb8B6e2AdvEcaQoyz2a_BFT3KS2HSsQAAAAQKKiVQAAABkStXddZUdd9ffL_GXA
+              accessTokenExpires:
+                type: string
+              refreshToken:
+                type: string
+              refreshTokenExpires:
+                type: string
       responses:
         "200":
           description: 소셜 로그인 성공

--- a/swagger/user.swagger.yml
+++ b/swagger/user.swagger.yml
@@ -261,3 +261,60 @@ paths:
               message:
                 type: string
                 example: 서버 에러, 관리자에게 문의 바랍니다.
+  /user/token/test:
+    post:
+      tags:
+        - User
+      summary: 테스트용 토큰 발급
+      description: 테스트용 액세스 토큰 발급 api입니다. userId 99번 유저로 발급됩니다.
+      responses:
+        "200":
+          description: 토큰 발급 성공
+          schema:
+            type: object
+            properties:
+              isSuccess:
+                type: boolean
+                example: true
+              code:
+                example: 2000
+              message:
+                type: string
+                example: success!
+              result:
+                type: object
+                properties:
+                  accessToken:
+                    type: string
+                    example: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VySWQiOjEyMiwibmlja25hbWUiOiJzdHJpbmciLCJrYWthb0lkIjozNjQ2Mzk1ODU5LCJjb25uZWN0ZWRBdCI6IjIwMjQtMDgtMDFUMDQ6MzI6MjJaIiwiaWF0IjoxNzIzMDA5MDQ2LCJleHAiOjE3MjMwMTI2NDZ9.bCGW7EZH6fEcLS_KZD5UOVBfuVlbK2vWmLuRoriUn3o
+        "400":
+          description: 토큰 발급 실패
+          schema:
+            type: object
+            properties:
+              isSuccess:
+                type: boolean
+                example: false
+              code:
+                type: integer
+                example: TOKEN002
+              message:
+                type: string
+                example: 서버 토큰 발급에 실패했습니다.
+        "500":
+          description: 서버 에러
+          schema:
+            type: object
+            properties:
+              status:
+                type: integer
+                example: 500
+              isSuccess:
+                type: boolean
+                example: false
+              code:
+                type: integer
+                example: COMMON000
+              message:
+                type: string
+                example: 서버 에러, 관리자에게 문의 바랍니다.


### PR DESCRIPTION
## 관련 이슈

- #50

## 요약 📝

- 카카오 로그인 로직 수정, Bearer 인증 헤더 처리, 테스트용 토큰 구현

## 상세 내용 🔥

- 카카오 로그인 로직이 수정되었습니다.
  - 전체 플로우: authcode 발급 ~ 카카오 토큰 발급 ~ 카카오 정보 추출 ~ 서버 토큰 발급
  - 프론트엔드에서 authcode까지만 발급하는 형식에서 이제는 카카오 토큰 발급까지 하게 되어, 서버에서는 카카오 토큰으로 정보 추출하여 서버 토큰을 발급합니다.
- authMiddleware에 Bearer 헤더로 왔을 경우를 처리하였습니다.
- 테스트용 토큰 발급이 가능합니다.

## 리뷰어에게 부탁, 유의사항 🙏

- 테스트용 토큰은 userId 99번 유저로 설정하였습니다.
- JWT 생성 및 카카오 로그인 관련 키는 노션에 업로드 되어있습니다.