### PR TITLE
[#55] Refactor: 알림&리스트 swagger 수정 및 "code": "2000"으로 수정

### DIFF
--- a/config/response.status.js
+++ b/config/response.status.js
@@ -2,11 +2,11 @@ import { StatusCodes } from "http-status-codes";
 
 export const status = {
     // success
-    SUCCESS: {status: StatusCodes.OK, "isSuccess": true, "code": 2000, "message": "success!"},
-    CREATED: {status: StatusCodes.CREATED, "isSuccess": true, "code": 2000, "message": "create success!"},
-    NICKNAME_VALID: {status: StatusCodes.OK, "isSuccess": true, "code": 2000, "message": "환상적인 닉네임이에요!"},
-    UPDATED: {status: StatusCodes.UPDATED, "isSuccess": true, "code": 2000, "message": "update success!"},
-    DELETED: {status: StatusCodes.DELETED, "isSuccess": true, "code": 2000, "message": "delete success!"},
+    SUCCESS: {status: StatusCodes.OK, "isSuccess": true, "code": "2000", "message": "success!"},
+    CREATED: {status: StatusCodes.CREATED, "isSuccess": true, "code": "2000", "message": "create success!"},
+    NICKNAME_VALID: {status: StatusCodes.OK, "isSuccess": true, "code": "2000", "message": "환상적인 닉네임이에요!"},
+    UPDATED: {status: StatusCodes.UPDATED, "isSuccess": true, "code": "2000", "message": "update success!"},
+    DELETED: {status: StatusCodes.DELETED, "isSuccess": true, "code": "2000", "message": "delete success!"},
 
     // error
     // common err

--- a/swagger/alertConfirm.swagger.yml
+++ b/swagger/alertConfirm.swagger.yml
@@ -17,19 +17,16 @@ paths:
           schema:
             type: object
             properties:
-              status:
-                type: integer
-                example: 200
               isSuccess:
                 type: boolean
                 example: true
               code:
-                type: integer
-                example: 2000
+                type: string
+                example: "2000"
               message:
                 type: string
                 example: "success!"
-              data:
+              result:
                 type: object
                 example:
                   {
@@ -40,9 +37,6 @@ paths:
           schema:
             type: object
             properties:
-              status:
-                type: integer
-                example: 400
               isSuccess:
                 type: boolean
                 example: false
@@ -57,9 +51,6 @@ paths:
           schema:
             type: object
             properties:
-              status:
-                type: integer
-                example: 500
               isSuccess:
                 type: boolean
                 example: false

--- a/swagger/alertCreate.swagger.yml
+++ b/swagger/alertCreate.swagger.yml
@@ -29,19 +29,16 @@ paths:
           schema:
             type: object
             properties:
-              status:
-                type: integer
-                example: 200
               isSuccess:
                 type: boolean
                 example: true
               code:
-                type: integer
-                example: 2000
+                type: string
+                example: "2000"
               message:
                 type: string
                 example: "success!"
-              data:
+              result:
                 type: object
                 example:
                   {
@@ -52,9 +49,6 @@ paths:
           schema:
             type: object
             properties:
-              status:
-                type: integer
-                example: 400
               isSuccess:
                 type: boolean
                 example: false
@@ -69,9 +63,6 @@ paths:
           schema:
             type: object
             properties:
-              status:
-                type: integer
-                example: 500
               isSuccess:
                 type: boolean
                 example: false

--- a/swagger/alertPreview.swagger.yml
+++ b/swagger/alertPreview.swagger.yml
@@ -6,44 +6,38 @@ paths:
       summary: 알림 조회
       responses:
         "200":
-          description: 알림 생성 성공!
+          description: 알림 조회 성공!
           schema:
             type: object
             properties:
-              status:
-                type: integer
-                example: 200
               isSuccess:
                 type: boolean
                 example: true
               code:
-                type: integer
-                example: 2000
+                type: string
+                example: "2000"
               message:
                 type: string
                 example: "success!"
-          data:
-            type: object
-            example:
-              {
-                "alert_id": 9,
-                "alert_status": 0,
-                "alert_date": "2025-05-25 15:30:00",
-                "alert_type": "original",
-                "link":{
-                    "id": 5,
-                    "title": "Link 2",
-                    "memo": "link 2 memo"
-                }
-              }
+              result:
+                type: object
+                example:
+                  {
+                    "alert_id": 9,
+                    "alert_status": 0,
+                    "alert_date": "2025-05-25 15:30:00",
+                    "alert_type": "original",
+                    "link":{
+                        "id": 5,
+                        "title": "Link 2",
+                        "memo": "link 2 memo"
+                    }
+                  }
         "400":
           description: 잘못된 요청
           schema:
             type: object
             properties:
-              status:
-                type: integer
-                example: 400
               isSuccess:
                 type: boolean
                 example: false
@@ -58,9 +52,6 @@ paths:
           schema:
             type: object
             properties:
-              status:
-                type: integer
-                example: 500
               isSuccess:
                 type: boolean
                 example: false

--- a/swagger/likelist.swagger.yml
+++ b/swagger/likelist.swagger.yml
@@ -21,64 +21,58 @@ paths:
           schema:
             type: object
             properties:
-              status:
-                type: integer
-                example: 200
               isSuccess:
                 type: boolean
                 example: true
               code:
-                type: integer
-                example: 2000
+                type: string
+                example: "2000"
               message:
                 type: string
                 example: "success!"
-          data:
-            type: object
-            example:
-              {
-                "links":
-                  [
-                    {
-                      "id": "1",
-                      "title": "Link 1",
-                      "url": "https://www.exaple.com/link1",
-                      "tag": "text",
-                      "thumbnail": "https://www.example.com/link1-thumbnail.jpg",
-                      "like": 1,
-                      "createdAt": "2024-07-15",
-                      "zip":
+              result:
+                type: object
+                example:
+                  {
+                    "links":
+                      [
                         {
                           "id": "1",
-                          "title": "Zip 1",
-                          "color": "blue"
+                          "title": "Link 1",
+                          "url": "https://www.exaple.com/link1",
+                          "tag": "text",
+                          "thumbnail": "https://www.example.com/link1-thumbnail.jpg",
+                          "like": 1,
+                          "createdAt": "2024-07-15",
+                          "zip":
+                            {
+                              "id": "1",
+                              "title": "Zip 1",
+                              "color": "blue"
+                            },
                         },
-                    },
-                    {
-                      "id": "2",
-                      "title": "Link 2",
-                      "url": "https://www.example.com/link2",
-                      "tag": "link",
-                      "thumbnail": "https://www.example.com/link2-thumbnail.jpg",
-                      "like": 0,
-                      "createdAt": "2024-07-15",
-                      "zip":
                         {
                           "id": "2",
-                          "title": "Zip 2",
-                          "color": "blue"
+                          "title": "Link 2",
+                          "url": "https://www.example.com/link2",
+                          "tag": "link",
+                          "thumbnail": "https://www.example.com/link2-thumbnail.jpg",
+                          "like": 1,
+                          "createdAt": "2024-07-15",
+                          "zip":
+                            {
+                              "id": "2",
+                              "title": "Zip 2",
+                              "color": "blue"
+                            },
                         },
-                    },
-                  ],
-              }
+                      ],
+                  }
         "400":
           description: 잘못된 요청
           schema:
             type: object
             properties:
-              status:
-                type: integer
-                example: 400
               isSuccess:
                 type: boolean
                 example: false
@@ -93,9 +87,6 @@ paths:
           schema:
             type: object
             properties:
-              status:
-                type: integer
-                example: 500
               isSuccess:
                 type: boolean
                 example: false

--- a/swagger/recentlist.swagger.yml
+++ b/swagger/recentlist.swagger.yml
@@ -21,64 +21,58 @@ paths:
           schema:
             type: object
             properties:
-              status:
-                type: integer
-                example: 200
               isSuccess:
                 type: boolean
                 example: true
               code:
-                type: integer
-                example: 2000
+                type: string
+                example: "2000"
               message:
                 type: string
                 example: "success!"
-          data:
-            type: object
-            example:
-              {
-                "links":
-                  [
-                    {
-                      "id": "1",
-                      "title": "Link 1",
-                      "url": "https://www.exaple.com/link1",
-                      "tag": "text",
-                      "thumbnail": "https://www.example.com/link1-thumbnail.jpg",
-                      "like": 1,
-                      "createdAt": "2024-07-15",
-                      "zip":
+              result:
+                type: object
+                example:
+                  {
+                    "links":
+                      [
                         {
                           "id": "1",
-                          "title": "Zip 1",
-                          "color": "blue"
+                          "title": "Link 1",
+                          "url": "https://www.exaple.com/link1",
+                          "tag": "text",
+                          "thumbnail": "https://www.example.com/link1-thumbnail.jpg",
+                          "like": 1,
+                          "createdAt": "2024-07-15",
+                          "zip":
+                            {
+                              "id": "1",
+                              "title": "Zip 1",
+                              "color": "blue"
+                            },
                         },
-                    },
-                    {
-                      "id": "2",
-                      "title": "Link 2",
-                      "url": "https://www.example.com/link2",
-                      "tag": "link",
-                      "thumbnail": "https://www.example.com/link2-thumbnail.jpg",
-                      "like": 0,
-                      "createdAt": "2024-07-15",
-                      "zip":
                         {
                           "id": "2",
-                          "title": "Zip 2",
-                          "color": "blue"
+                          "title": "Link 2",
+                          "url": "https://www.example.com/link2",
+                          "tag": "link",
+                          "thumbnail": "https://www.example.com/link2-thumbnail.jpg",
+                          "like": 0,
+                          "createdAt": "2024-07-15",
+                          "zip":
+                            {
+                              "id": "2",
+                              "title": "Zip 2",
+                              "color": "blue"
+                            },
                         },
-                    },
-                  ],
-              }
+                      ],
+                  }
         "400":
           description: 잘못된 요청
           schema:
             type: object
             properties:
-              status:
-                type: integer
-                example: 400
               isSuccess:
                 type: boolean
                 example: false
@@ -93,9 +87,6 @@ paths:
           schema:
             type: object
             properties:
-              status:
-                type: integer
-                example: 500
               isSuccess:
                 type: boolean
                 example: false

--- a/swagger/unsightlist.swagger.yml
+++ b/swagger/unsightlist.swagger.yml
@@ -21,64 +21,58 @@ paths:
           schema:
             type: object
             properties:
-              status:
-                type: integer
-                example: 200
               isSuccess:
                 type: boolean
                 example: true
               code:
-                type: integer
-                example: 2000
+                type: string
+                example: "2000"
               message:
                 type: string
                 example: "success!"
-          data:
-            type: object
-            example:
-              {
-                "links":
-                  [
-                    {
-                      "id": "1",
-                      "title": "Link 1",
-                      "url": "https://www.exaple.com/link1",
-                      "tag": "text",
-                      "thumbnail": "https://www.example.com/link1-thumbnail.jpg",
-                      "like": 1,
-                      "createdAt": "2024-07-15",
-                      "zip":
+              result:
+                type: object
+                example:
+                  {
+                    "links":
+                      [
                         {
                           "id": "1",
-                          "title": "Zip 1",
-                          "color": "blue"
+                          "title": "Link 1",
+                          "url": "https://www.exaple.com/link1",
+                          "tag": "text",
+                          "thumbnail": "https://www.example.com/link1-thumbnail.jpg",
+                          "like": 1,
+                          "createdAt": "2024-07-15",
+                          "zip":
+                            {
+                              "id": "1",
+                              "title": "Zip 1",
+                              "color": "blue"
+                            },
                         },
-                    },
-                    {
-                      "id": "2",
-                      "title": "Link 2",
-                      "url": "https://www.example.com/link2",
-                      "tag": "link",
-                      "thumbnail": "https://www.example.com/link2-thumbnail.jpg",
-                      "like": 0,
-                      "createdAt": "2024-07-15",
-                      "zip":
                         {
                           "id": "2",
-                          "title": "Zip 2",
-                          "color": "blue"
+                          "title": "Link 2",
+                          "url": "https://www.example.com/link2",
+                          "tag": "link",
+                          "thumbnail": "https://www.example.com/link2-thumbnail.jpg",
+                          "like": 0,
+                          "createdAt": "2024-07-15",
+                          "zip":
+                            {
+                              "id": "2",
+                              "title": "Zip 2",
+                              "color": "blue"
+                            },
                         },
-                    },
-                  ],
-              }
+                      ],
+                  }
         "400":
           description: 잘못된 요청
           schema:
             type: object
             properties:
-              status:
-                type: integer
-                example: 400
               isSuccess:
                 type: boolean
                 example: false
@@ -93,9 +87,6 @@ paths:
           schema:
             type: object
             properties:
-              status:
-                type: integer
-                example: 500
               isSuccess:
                 type: boolean
                 example: false


### PR DESCRIPTION
## 관련 이슈

- #55 

## 요약 📝

- 알림 및 리스트 API의 Swagger 문서 수정
- 응답 코드 2000을 문자열 "2000"으로 수정

## 상세 내용 🔥

- 코드 수정: response.status.js 파일에서 code: 2000을 code: "2000"으로 변경했습니다.
- 알림 및 리스트 API의 Swagger 문서에서 잘못된 예시와 혼동을 일으킬 수 있는 문구를 수정했습니다.

## 리뷰어에게 부탁, 유의사항 🙏

- SUCCESS 코드 외에도 사용자 성공 관련 코드에 대해 code: "2000"으로 변경했습니다.
- 리스트/알림 swagger외에 다른 swagger 문서도 변경이 필요할 수 있으므로 확인 부탁드립니다. 