### PR TITLE
[#54] Refactor: User 응답형식 수정

### DIFF
--- a/src/controllers/user.controller.js
+++ b/src/controllers/user.controller.js
@@ -37,7 +37,7 @@ export const kakaoLoginCnt = async (req, res, next) => {
                 connectedAt: kakaoUserInfo.connected_at,
             };
             const tokenResponse = await generateToken(payload);
-            res.send(response(status.SUCCESS, tokenResponse));
+            res.send(response(status.SUCCESS, {isExists: true, tokenResponse: tokenResponse}));
         } else {
             res.send(response(status.SUCCESS, result));
         }
@@ -94,8 +94,7 @@ export const getTestTokenCnt = async (req, res, next) => {
     };
 
     try {
-        const token = await generateToken(payload);
-
+        const tokenResponse = await generateToken(payload);
         res.send(response(status.SUCCESS, tokenResponse));
     } catch (error) {
         throw new BaseError(status.SERVER_TOKEN_ERROR); // jwt 발급 실패시

--- a/src/controllers/user.controller.js
+++ b/src/controllers/user.controller.js
@@ -2,17 +2,15 @@ import jwt from 'jsonwebtoken';
 import { BaseError } from "@config/error";
 import { response } from "@config/response.js";
 import { status } from '@config/response.status.js';
-import { addUserSer, getUserSer, checkNicknameSer, getUserByKakaoId } from '@services/user.service.js';
+import { addUserSer, getUserSer, checkNicknameSer, getUserByKakaoId, generateToken } from '@services/user.service.js';
 import { getKakaoUserInfo } from "@providers/user.provider.js";
+import { userLoginResponseDTO } from '@dtos/user.dto';
 
 /** 카카오 로그인 및 jwt 생성 */
 export const kakaoLoginCnt = async (req, res, next) => {
-    // const { authCode } = req.body;
-    // const kakaoUserInfo = await getKakaoUserInfo(authCode); // authCode로 카카오 토큰 발급
-
     const { accessToken, accessTokenExpires, refreshToken, refreshTokenExpires } = req.body;
     const kakaoUserInfo = await getKakaoUserInfo(accessToken);
-    
+
     /** TODO : 카카오 토큰 갱신 로직 */
     // try {
     //     kakaoUserInfo = await getKakaoUserInfo(accessToken); // 카카오 토큰으로 카카오 유저 정보 조회
@@ -28,18 +26,21 @@ export const kakaoLoginCnt = async (req, res, next) => {
     //     }
     // }
 
-    const result = await getUserByKakaoId(kakaoUserInfo.id); // 신규 유저일 시 여기서 throw
-
-    const payload = {
-        userId: result.userId,
-        nickname: result.nickname,
-        kakaoId: kakaoUserInfo.id,
-        connectedAt: kakaoUserInfo.connected_at,
-    };
-
     try {
-        const token = jwt.sign(payload, process.env.JWT_SECRET, { expiresIn: '1h' });
-        res.send(response(status.SUCCESS, {accessToken: token}));
+        const result = await getUserByKakaoId(kakaoUserInfo.id);
+
+        if (result.isExists) { // 기존 유저임
+            const payload = {
+                userId: result.userId,
+                nickname: result.nickname,
+                kakaoId: kakaoUserInfo.id,
+                connectedAt: kakaoUserInfo.connected_at,
+            };
+            const tokenResponse = await generateToken(payload);
+            res.send(response(status.SUCCESS, tokenResponse));
+        } else {
+            res.send(response(status.SUCCESS, result));
+        }
     } catch (error) {
         throw new BaseError(status.SERVER_TOKEN_ERROR); // jwt 발급 실패시
     }
@@ -57,13 +58,11 @@ export const addUserCnt = async (req, res, next) => {
     };
 
     try {
-        const token = jwt.sign(payload, process.env.JWT_SECRET, { expiresIn: '1h' });
-        res.send(response(status.SUCCESS, {accessToken: token}));
+        const tokenResponse = await generateToken(payload); // 지금은 일단 accessToken만 발급
+        res.send(response(status.SUCCESS, tokenResponse));
     } catch (error) {
         throw new BaseError(status.SERVER_TOKEN_ERROR); // jwt 발급 실패시
     }
-
-    
 }
 
 /** 사용자 조회 컨트롤러 (userId) */
@@ -80,9 +79,10 @@ export const checkNicknameCnt = async (req, res, next) => {
         throw new BaseError(status.BAD_REQUEST);
     }
 
-    return res.send(response(status.NICKNAME_VALID, await checkNicknameSer(nickname)));
+    return res.send(response(status.SUCCESS, await checkNicknameSer(nickname)));
 }
 
+/** 테스트 토큰 발급 */
 export const getTestTokenCnt = async (req, res, next) => {
     const result = await getUserSer(99);
 
@@ -94,8 +94,9 @@ export const getTestTokenCnt = async (req, res, next) => {
     };
 
     try {
-        const token = jwt.sign(payload, process.env.JWT_SECRET, { expiresIn: '1h' });
-        res.send(response(status.SUCCESS, {accessToken: token}));
+        const token = await generateToken(payload);
+
+        res.send(response(status.SUCCESS, tokenResponse));
     } catch (error) {
         throw new BaseError(status.SERVER_TOKEN_ERROR); // jwt 발급 실패시
     }

--- a/src/dtos/user.dto.js
+++ b/src/dtos/user.dto.js
@@ -7,3 +7,10 @@ export const userResponseDTO = (data) => {
         createdAt: data.created_at,
     }
 }
+
+export const userTokenResponseDTO = (token, expiresIn) => {
+    return {
+        accessToken: token,
+        accessTokenExpiresIn: expiresIn,
+    }
+}

--- a/src/models/user.dao.js
+++ b/src/models/user.dao.js
@@ -6,9 +6,9 @@ import { checkNicknameSql, insertUserSql, selectUserSql, selectUserByKakaoIdSql 
 
 /** 회원가입 DAO, id 리턴 */
 export const addUserDao = async (data) => {
+    let conn;
     try {
-        const conn = await pool.getConnection();
-        
+        conn = await pool.getConnection();
         const [[isValid]] = await conn.query(checkNicknameSql, data.nickname);
         if (isValid.count > 0) {
             conn.release();
@@ -24,43 +24,54 @@ export const addUserDao = async (data) => {
     } catch (error) {
         console.error(error);
         throw new BaseError(status.BAD_REQUEST);
+    } finally {
+        if (conn) conn.release();
     }
 }
 
 /** 사용자 정보 조회 DAO */
 export const getUserDao = async (userId) => {
+    let conn;
     try {
-        const conn = await pool.getConnection();
+        conn = await pool.getConnection();
         const [[result]] = await conn.query(selectUserSql, userId);
         conn.release();
         return result;
     } catch (error) {
         console.error(error);
         throw new BaseError(status.BAD_REQUEST);
-    }   
+    } finally {
+        if (conn) conn.release();
+    }
 }
 
 export const getUserByKakaoIdDao = async (kakaoId) => {
+    let conn;
     try {
-        const conn = await pool.getConnection();
+        conn = await pool.getConnection();
         const [[result]] = await conn.query(selectUserByKakaoIdSql, kakaoId);
         conn.release();
         return result;
     } catch (error) {
         console.error(error);
         throw new BaseError(status.BAD_REQUEST);
+    } finally {
+        if (conn) conn.release();
     }
 }
 
 /** 닉네임 중복 체크 DAO */
 export const checkNicknameDao = async (nickname) => {
+    let conn;
     try {
-        const conn = await pool.getConnection();
+        conn = await pool.getConnection();
         const [[result]] = await conn.query(checkNicknameSql, nickname);
         conn.release();
         return result; // count 반환
     } catch (error) {
         console.error(error);
         throw new BaseError(status.BAD_REQUEST);
+    } finally {
+        if (conn) conn.release();
     }
 }

--- a/src/providers/user.provider.js
+++ b/src/providers/user.provider.js
@@ -28,7 +28,7 @@ export const getKakaoToken = async (authCode) => {
                 },
             }
         );
-    
+
         return userInfoResponse.data;
     } catch (error) {
         throw new BaseError(status.KAKAO_TOKEN_ERROR);
@@ -46,7 +46,6 @@ export const getKakaoUserInfo = async (kakaoToken) => {
                 },
             }
         );
-    
         return userInfoResponse.data;
     } catch (error) {
         throw new BaseError(status.KAKAO_TOKEN_ERROR);

--- a/src/services/user.service.js
+++ b/src/services/user.service.js
@@ -71,6 +71,6 @@ export const getUserSer = async (userId) => {
 /** 토큰 생성 */
 export const generateToken = async (payload) => {
     const token = jwt.sign(payload, process.env.JWT_SECRET, { expiresIn: '1h' });
-    const expiresIn = new Date(Date.now() + 60 * 60 * 1000).toISOString();
+    const expiresIn = new Date(Date.now() + 60 * 60 * 1000);
     return userTokenResponseDTO(token, expiresIn);
 }


### PR DESCRIPTION
## 관련 이슈

- #54

## 요약 📝

- User 관련 api의 응답형식을 수정하였습니다.

## 상세 내용 🔥

- 회원가입 응답형식을 수정하였습니다.
  - 로그인시 카카오 토큰 객체를 받으며, 현재는 여기서 accessToken만 떼어 유저 정보를 조회합니다.
- 신규 유저
```json
    "result": {
        "isExists": false,
        "key": "4ea5c508a6566e76240543f8feb06fd457777be39549c4016436afda65d2330e"
    }
```
- 기존 유저
```json
    "result": {
        "isExists": true,
        "tokenResponse": {
              "accessToken": "eyJ어쩌구저쩌구",
              "accessTokenExpiresIn": "2024-08-17T11:24:11.114Z"
         }
    }
```
- 회원가입 시에도 tokenResponse 객체로 묶어서 데이터가 나갑니다.
- 닉네임 중복체크 응답형식을 수정했습니다.
  - 중복 시에도 200으로 전송되며, result 에 true(중복아님)/false(중복임) 로 중복 여부가 내려갑니다. 
  - 이거는 지금 제가보기엔 먼가 가독성이 별로라서, isValid 나 isDuplicated 같은걸로 감싸는게 좋을 것 같아요
- user dao에 finally 구문을 사용하여 에러 시에 커넥션이 무조건 release되도록 하였습니다.
- 스웨거 응답예시는 추후 수정하겠습니다... 흑

## 리뷰어에게 부탁, 유의사항 🙏

- 
