### PR TITLE
[#41] Feat: redis를 사용한 key, refresh token 관리

### DIFF
--- a/config/authMiddleware.js
+++ b/config/authMiddleware.js
@@ -15,7 +15,11 @@ export const tokenAuthMiddleware = (req, res, next) => {
 
     jwt.verify(token, process.env.JWT_SECRET, (err, decoded) => {
         if (err) {
-            throw new BaseError(status.UNAUTHORIZED);
+            if (err.name === 'TokenExpiredError') {
+                throw new BaseError(status.TOKEN_EXPIRED);
+            } else {
+                throw new BaseError(status.UNAUTHORIZED);
+            }
         }
         req.userId = decoded.userId;
         next();

--- a/config/redis.js
+++ b/config/redis.js
@@ -1,0 +1,9 @@
+import { createClient } from "redis";
+
+const redisClient = createClient({ 
+    url: process.env.REDIS_URL || 'redis://localhost:6379'
+});
+
+redisClient.on('error', (err) => console.error('Redis error: ', err)); // redis 연결 에러처리
+
+export { redisClient };

--- a/config/redis.js
+++ b/config/redis.js
@@ -1,7 +1,10 @@
 import { createClient } from "redis";
 
 const redisClient = createClient({ 
-    url: process.env.REDIS_URL || 'redis://localhost:6379'
+    url: process.env.REDIS_URL || 'redis://localhost:6379',
+    socket: {
+        tls: process.env.NODE_ENV === 'production' ? true : false,
+    },
 });
 
 redisClient.on('error', (err) => console.error('Redis error: ', err)); // redis 연결 에러처리

--- a/config/response.status.js
+++ b/config/response.status.js
@@ -40,7 +40,7 @@ export const status = {
 
     // token error
     KAKAO_TOKEN_ERROR: {status: StatusCodes.UNAUTHORIZED, "isSuccess": false, "code": "TOKEN001", "message": "카카오 토큰 인증에 실패했습니다." },
-    SERVER_TOKEN_ERROR: {status: StatusCodes.BAD_REQUEST, "isSuccess": false, "code": "TOKEN002", "message": "서버 토큰 발급에 실패했습니다." },
+    SERVER_TOKEN_ERROR: {status: StatusCodes.UNAUTHORIZED, "isSuccess": false, "code": "TOKEN002", "message": "서버 토큰 발급에 실패했습니다." },
     TOKEN_INVALID: {status: StatusCodes.UNAUTHORIZED, "isSuccess": false, "code": "TOKEN003", "message": "유효하지 않은 토큰입니다." },
     TOKEN_EXPIRED: {status: StatusCodes.UNAUTHORIZED, "isSuccess": false, "code": "TOKEN004", "message": "토큰이 만료되었습니다." },
 

--- a/config/session.js
+++ b/config/session.js
@@ -1,0 +1,22 @@
+import session from "express-session"; 
+import RedisStore from "connect-redis";
+import { redisClient } from "./redis";
+
+const redisStore = new RedisStore({
+    client: redisClient,
+    prefix: 'session:',
+});
+
+const sessionMiddleware = session({
+    store: redisStore,
+    secret: process.env.SESSION_SECRET,
+    resave: false,
+    saveUninitialized: false,
+    cookie: {
+        httpOnly: true,
+        secure: false,
+        domain: '*',
+    },
+});
+
+export { sessionMiddleware };

--- a/config/session.js
+++ b/config/session.js
@@ -14,7 +14,7 @@ const sessionMiddleware = session({
     saveUninitialized: false,
     cookie: {
         httpOnly: true,
-        secure: false,
+        secure: process.env.NODE_ENV === 'production',
         domain: '*',
     },
 });

--- a/index.js
+++ b/index.js
@@ -50,7 +50,7 @@ app.post('/user/login', asyncHandler(kakaoLoginCnt)); // 로그인
 app.get('/user', asyncHandler(checkNicknameCnt)); // 닉네임 중복 체크
 app.post('/user', asyncHandler(addUserCnt)); // 회원가입
 app.post('/user/token/test', asyncHandler(getTestTokenCnt)); // 테스트용 토큰 발급
-app.post("/user/refresh", asyncHandler(refreshTokenCnt)); // 토큰 재발급
+app.post('/user/refresh', asyncHandler(refreshTokenCnt)); // 토큰 재발급
 app.use('/api-docs', SwaggerUi.serve, SwaggerUi.setup(specs));
 
 // 모든 route에 대해 검증 미들웨어 적용

--- a/index.js
+++ b/index.js
@@ -11,6 +11,8 @@ import { status } from '@config/response.status.js';
 import { response } from '@config/response.js';
 import { pool } from '@config/db.config.js';
 import { tokenAuthMiddleware } from '@config/authMiddleware';
+import { sessionMiddleware } from '@config/session';
+import { redisClient } from '@config/redis';
 
 import { alertRouter } from '@routes/alert.route.js';
 import { userRouter } from '@routes/user.route.js';
@@ -33,6 +35,14 @@ app.use(express.static('public'));          // 정적 파일 접근
 app.use(express.json());                    // request의 본문을 json으로 해석할 수 있도록
 app.use(express.urlencoded({extended: true})); // 단순 객체 문자열 형태로 본문 데이터 해석
 app.use(cookieParser());                    // 쿠키 데이터 전송 전달 허용
+
+redisClient
+    .connect()
+    .then(() => console.log('✅ Redis 연결 성공'))
+    .catch((err) => console.error('❌ Redis 연결 실패', err));
+
+app.use(cookieParser('session'));
+app.use(sessionMiddleware);
 
 
 // 토큰 검증 예외 라우트

--- a/index.js
+++ b/index.js
@@ -23,7 +23,7 @@ import { noticeRouter } from '@routes/notice.route';
 import { searchRouter } from '@routes/search.route';
 import { linkscountrouter } from '@routes/linkscount.route.js';
 
-import { addUserCnt, checkNicknameCnt, getTestTokenCnt, kakaoLoginCnt } from '@controllers/user.controller';
+import { addUserCnt, checkNicknameCnt, getTestTokenCnt, kakaoLoginCnt, refreshTokenCnt } from '@controllers/user.controller';
 
 dotenv.config();
 
@@ -50,6 +50,7 @@ app.post('/user/login', asyncHandler(kakaoLoginCnt)); // 로그인
 app.get('/user', asyncHandler(checkNicknameCnt)); // 닉네임 중복 체크
 app.post('/user', asyncHandler(addUserCnt)); // 회원가입
 app.post('/user/token/test', asyncHandler(getTestTokenCnt)); // 테스트용 토큰 발급
+app.post("/user/refresh", asyncHandler(refreshTokenCnt)); // 토큰 재발급
 app.use('/api-docs', SwaggerUi.serve, SwaggerUi.setup(specs));
 
 // 모든 route에 대해 검증 미들웨어 적용

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "axios": "^1.7.2",
         "cheerio": "^1.0.0-rc.12",
+        "connect-redis": "^7.1.1",
         "cookie-parser": "^1.4.6",
         "cors": "^2.8.5",
         "crypto-js": "^4.2.0",
@@ -21,6 +22,7 @@
         "jsonwebtoken": "^9.0.2",
         "mysql2": "^3.10.2",
         "openai": "^4.52.7",
+        "redis": "^4.7.0",
         "swagger-cli": "^4.0.4",
         "swagger-jsdoc": "^6.2.8",
         "swagger-ui-express": "^5.0.1"
@@ -2048,6 +2050,64 @@
       "dev": true,
       "optional": true
     },
+    "node_modules/@redis/bloom": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@redis/bloom/-/bloom-1.2.0.tgz",
+      "integrity": "sha512-HG2DFjYKbpNmVXsa0keLHp/3leGJz1mjh09f2RLGGLQZzSHpkmZWuwJbAvo3QcRY8p80m5+ZdXZdYOSBLlp7Cg==",
+      "peerDependencies": {
+        "@redis/client": "^1.0.0"
+      }
+    },
+    "node_modules/@redis/client": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@redis/client/-/client-1.6.0.tgz",
+      "integrity": "sha512-aR0uffYI700OEEH4gYnitAnv3vzVGXCFvYfdpu/CJKvk4pHfLPEy/JSZyrpQ+15WhXe1yJRXLtfQ84s4mEXnPg==",
+      "dependencies": {
+        "cluster-key-slot": "1.1.2",
+        "generic-pool": "3.9.0",
+        "yallist": "4.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@redis/client/node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+    },
+    "node_modules/@redis/graph": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@redis/graph/-/graph-1.1.1.tgz",
+      "integrity": "sha512-FEMTcTHZozZciLRl6GiiIB4zGm5z5F3F6a6FZCyrfxdKOhFlGkiAqlexWMBzCi4DcRoyiOsuLfW+cjlGWyExOw==",
+      "peerDependencies": {
+        "@redis/client": "^1.0.0"
+      }
+    },
+    "node_modules/@redis/json": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/@redis/json/-/json-1.0.7.tgz",
+      "integrity": "sha512-6UyXfjVaTBTJtKNG4/9Z8PSpKE6XgSyEb8iwaqDcy+uKrd/DGYHTWkUdnQDyzm727V7p21WUMhsqz5oy65kPcQ==",
+      "peerDependencies": {
+        "@redis/client": "^1.0.0"
+      }
+    },
+    "node_modules/@redis/search": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@redis/search/-/search-1.2.0.tgz",
+      "integrity": "sha512-tYoDBbtqOVigEDMAcTGsRlMycIIjwMCgD8eR2t0NANeQmgK/lvxNAvYyb6bZDD4frHRhIHkJu2TBRvB0ERkOmw==",
+      "peerDependencies": {
+        "@redis/client": "^1.0.0"
+      }
+    },
+    "node_modules/@redis/time-series": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@redis/time-series/-/time-series-1.1.0.tgz",
+      "integrity": "sha512-c1Q99M5ljsIuc4YdaCwfUEXsofakb9c8+Zse2qxTadu8TalLXuAESzLvFAvNVbkmSlvlzIQOLpBCmWI9wTOt+g==",
+      "peerDependencies": {
+        "@redis/client": "^1.0.0"
+      }
+    },
     "node_modules/@types/node": {
       "version": "18.19.39",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.39.tgz",
@@ -2622,6 +2682,14 @@
         "node": ">=6"
       }
     },
+    "node_modules/cluster-key-slot": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/cluster-key-slot/-/cluster-key-slot-1.1.2.tgz",
+      "integrity": "sha512-RMr0FhtfXemyinomL4hrWcYJxmX6deFdCxpJzhDttxgO1+bcCnkk+9drydLVDmAMG7NE6aN/fl4F7ucU/90gAA==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/color-convert": {
       "version": "1.9.3",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
@@ -2667,6 +2735,17 @@
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="
+    },
+    "node_modules/connect-redis": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/connect-redis/-/connect-redis-7.1.1.tgz",
+      "integrity": "sha512-M+z7alnCJiuzKa8/1qAYdGUXHYfDnLolOGAUjOioB07pP39qxjG+X9ibsud7qUBc4jMV5Mcy3ugGv8eFcgamJQ==",
+      "engines": {
+        "node": ">=16"
+      },
+      "peerDependencies": {
+        "express-session": ">=1"
+      }
     },
     "node_modules/content-disposition": {
       "version": "0.5.4",
@@ -3275,6 +3354,31 @@
       "resolved": "https://registry.npmjs.org/express-async-handler/-/express-async-handler-1.2.0.tgz",
       "integrity": "sha512-rCSVtPXRmQSW8rmik/AIb2P0op6l7r1fMW538yyvTMltCO4xQEWMmobfrIxN2V1/mVrgxB8Az3reYF6yUZw37w=="
     },
+    "node_modules/express-session": {
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/express-session/-/express-session-1.18.0.tgz",
+      "integrity": "sha512-m93QLWr0ju+rOwApSsyso838LQwgfs44QtOP/WBiwtAgPIo/SAh1a5c6nn2BR6mFNZehTpqKDESzP+fRHVbxwQ==",
+      "peer": true,
+      "dependencies": {
+        "cookie": "0.6.0",
+        "cookie-signature": "1.0.7",
+        "debug": "2.6.9",
+        "depd": "~2.0.0",
+        "on-headers": "~1.0.2",
+        "parseurl": "~1.3.3",
+        "safe-buffer": "5.2.1",
+        "uid-safe": "~2.1.5"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/express-session/node_modules/cookie-signature": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.7.tgz",
+      "integrity": "sha512-NXdYc3dLr47pBkpUCHtKSwIOQXLVn8dZEuywboCOJY/osA0wFSLlSawr3KN8qXJEyX66FcONTH8EIlVuK0yyFA==",
+      "peer": true
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -3493,6 +3597,14 @@
       "integrity": "sha512-eeB5GfMNeevm/GRYq20ShmsaGcmI81kIX2K9XQx5miC8KdHaC6Jm0qQ8ZNeGOi7wYB8OsdxKs+Y2oVuTFuVwKQ==",
       "dependencies": {
         "is-property": "^1.0.2"
+      }
+    },
+    "node_modules/generic-pool": {
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/generic-pool/-/generic-pool-3.9.0.tgz",
+      "integrity": "sha512-hymDOu5B53XvN4QT9dBmZxPX4CWhBPPLguTZ9MMFeFa/Kg0xWVfylOVNlJji/E7yTZWFd/q9GO5TxDLq156D7g==",
+      "engines": {
+        "node": ">= 4"
       }
     },
     "node_modules/gensync": {
@@ -4692,6 +4804,15 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/on-headers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.0.2.tgz",
+      "integrity": "sha512-pZAE+FJLoyITytdqK0U5s+FIpjN0JP3OzFi/u8Rx+EV5/W+JTWGXG8xFzevE7AjBfDqHv/8vL8qQsIhHnqRkrA==",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -4970,6 +5091,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/random-bytes": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/random-bytes/-/random-bytes-1.0.0.tgz",
+      "integrity": "sha512-iv7LhNVO047HzYR3InF6pUcUsPQiHTM1Qal51DcGSuZFBil1aBBWG5eHPNek7bvILMaYJ/8RU1e8w1AMdHmLQQ==",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/range-parser": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
@@ -5002,6 +5132,19 @@
       },
       "engines": {
         "node": ">=8.10.0"
+      }
+    },
+    "node_modules/redis": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/redis/-/redis-4.7.0.tgz",
+      "integrity": "sha512-zvmkHEAdGMn+hMRXuMBtu4Vo5P6rHQjLoHftu+lBqq8ZTA3RCVC/WzD790bkKKiNFp7d5/9PcSD19fJyyRvOdQ==",
+      "dependencies": {
+        "@redis/bloom": "1.2.0",
+        "@redis/client": "1.6.0",
+        "@redis/graph": "1.1.1",
+        "@redis/json": "1.0.7",
+        "@redis/search": "1.2.0",
+        "@redis/time-series": "1.1.0"
       }
     },
     "node_modules/regenerate": {
@@ -5725,6 +5868,18 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/uid-safe": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/uid-safe/-/uid-safe-2.1.5.tgz",
+      "integrity": "sha512-KPHm4VL5dDXKz01UuEd88Df+KzynaohSL9fBh096KWAxSKZQDI2uBrVqtvRM4rwrIrRRKsdLNML/lnaaVSRioA==",
+      "peer": true,
+      "dependencies": {
+        "random-bytes": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/unbox-primitive": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "dotenv": "^16.4.5",
         "express": "^4.19.2",
         "express-async-handler": "^1.2.0",
+        "express-session": "^1.18.0",
         "http-status-codes": "^2.3.0",
         "jsonwebtoken": "^9.0.2",
         "mysql2": "^3.10.2",
@@ -3358,7 +3359,6 @@
       "version": "1.18.0",
       "resolved": "https://registry.npmjs.org/express-session/-/express-session-1.18.0.tgz",
       "integrity": "sha512-m93QLWr0ju+rOwApSsyso838LQwgfs44QtOP/WBiwtAgPIo/SAh1a5c6nn2BR6mFNZehTpqKDESzP+fRHVbxwQ==",
-      "peer": true,
       "dependencies": {
         "cookie": "0.6.0",
         "cookie-signature": "1.0.7",
@@ -3376,8 +3376,7 @@
     "node_modules/express-session/node_modules/cookie-signature": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.7.tgz",
-      "integrity": "sha512-NXdYc3dLr47pBkpUCHtKSwIOQXLVn8dZEuywboCOJY/osA0wFSLlSawr3KN8qXJEyX66FcONTH8EIlVuK0yyFA==",
-      "peer": true
+      "integrity": "sha512-NXdYc3dLr47pBkpUCHtKSwIOQXLVn8dZEuywboCOJY/osA0wFSLlSawr3KN8qXJEyX66FcONTH8EIlVuK0yyFA=="
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
@@ -4808,7 +4807,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.0.2.tgz",
       "integrity": "sha512-pZAE+FJLoyITytdqK0U5s+FIpjN0JP3OzFi/u8Rx+EV5/W+JTWGXG8xFzevE7AjBfDqHv/8vL8qQsIhHnqRkrA==",
-      "peer": true,
       "engines": {
         "node": ">= 0.8"
       }
@@ -5095,7 +5093,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/random-bytes/-/random-bytes-1.0.0.tgz",
       "integrity": "sha512-iv7LhNVO047HzYR3InF6pUcUsPQiHTM1Qal51DcGSuZFBil1aBBWG5eHPNek7bvILMaYJ/8RU1e8w1AMdHmLQQ==",
-      "peer": true,
       "engines": {
         "node": ">= 0.8"
       }
@@ -5874,7 +5871,6 @@
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/uid-safe/-/uid-safe-2.1.5.tgz",
       "integrity": "sha512-KPHm4VL5dDXKz01UuEd88Df+KzynaohSL9fBh096KWAxSKZQDI2uBrVqtvRM4rwrIrRRKsdLNML/lnaaVSRioA==",
-      "peer": true,
       "dependencies": {
         "random-bytes": "~1.0.0"
       },

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   "dependencies": {
     "axios": "^1.7.2",
     "cheerio": "^1.0.0-rc.12",
+    "connect-redis": "^7.1.1",
     "cookie-parser": "^1.4.6",
     "cors": "^2.8.5",
     "crypto-js": "^4.2.0",
@@ -31,6 +32,7 @@
     "jsonwebtoken": "^9.0.2",
     "mysql2": "^3.10.2",
     "openai": "^4.52.7",
+    "redis": "^4.7.0",
     "swagger-cli": "^4.0.4",
     "swagger-jsdoc": "^6.2.8",
     "swagger-ui-express": "^5.0.1"

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "dotenv": "^16.4.5",
     "express": "^4.19.2",
     "express-async-handler": "^1.2.0",
+    "express-session": "^1.18.0",
     "http-status-codes": "^2.3.0",
     "jsonwebtoken": "^9.0.2",
     "mysql2": "^3.10.2",

--- a/src/controllers/user.controller.js
+++ b/src/controllers/user.controller.js
@@ -124,6 +124,7 @@ export const getTestTokenCnt = async (req, res, next) => {
 
     try {
         const tokenResponse = await generateToken(payload);
+        await setRefreshTokenCache(result.userId, tokenResponse.refreshToken); // redis 저장
         return res.send(response(status.SUCCESS, tokenResponse));
     } catch (error) {
         throw new BaseError(status.SERVER_TOKEN_ERROR); // jwt 발급 실패시

--- a/src/controllers/user.controller.js
+++ b/src/controllers/user.controller.js
@@ -2,7 +2,8 @@ import { BaseError } from "@config/error";
 import { response } from "@config/response.js";
 import { status } from '@config/response.status.js';
 import { addUserSer, getUserSer, checkNicknameSer, getUserByKakaoId, generateToken, patchUserInfoSer } from '@services/user.service.js';
-import { getKakaoUserInfo } from "@providers/user.provider.js";
+import { getKakaoUserInfo, setRefreshTokenCache } from "@providers/user.provider.js";
+import { refresh } from "src/utils/jwt.util";
 
 /** 카카오 로그인 및 jwt 생성 */
 export const kakaoLoginCnt = async (req, res, next) => {
@@ -36,7 +37,7 @@ export const kakaoLoginCnt = async (req, res, next) => {
             const tokenResponse = await generateToken(payload);
             await setRefreshTokenCache(result.userId, tokenResponse.refreshToken); // redis 저장
 
-            res.send(response(status.SUCCESS, {isExists: true, tokenResponse: tokenResponse}));
+            return res.send(response(status.SUCCESS, {isExists: true, tokenResponse: tokenResponse}));
         } else {
             return res.send(response(status.SUCCESS, result));
         }
@@ -57,7 +58,7 @@ export const addUserCnt = async (req, res, next) => {
     try {
         const tokenResponse = await generateToken(payload);
         await setRefreshTokenCache(result.userId, tokenResponse.refreshToken); // redis 저장
-        res.send(response(status.SUCCESS, tokenResponse));
+        return res.send(response(status.SUCCESS, tokenResponse));
     } catch (error) {
         throw new BaseError(status.SERVER_TOKEN_ERROR); // jwt 발급 실패시
     }

--- a/src/dtos/user.dto.js
+++ b/src/dtos/user.dto.js
@@ -27,6 +27,13 @@ export const userTokenResponseDTO = (access, accessExpiresIn, refresh, refreshEx
     }
 }
 
+export const userAccessTokenResponseDTO = (access, accessExpiresIn) => {
+    return {
+        accessToken: access,
+        accessTokenExpiresIn: accessExpiresIn,
+    }
+}
+
 /** 닉네임 중복 여부 반환 DTO */
 export const checkNicknameDTO = (isValid) => {
     return {

--- a/src/dtos/user.dto.js
+++ b/src/dtos/user.dto.js
@@ -18,7 +18,7 @@ export const userUpdateDTO = (data) => {
 }
 
 /** 토큰 반환 DTO */
-export const userTokenResponseDTO = (token, expiresIn) => {
+export const userTokenResponseDTO = (access, accessExpiresIn, refresh, refreshExpiresIn) => {
     return {
         accessToken: access,
         accessTokenExpiresIn: accessExpiresIn,

--- a/src/dtos/user.dto.js
+++ b/src/dtos/user.dto.js
@@ -20,8 +20,10 @@ export const userUpdateDTO = (data) => {
 /** 토큰 반환 DTO */
 export const userTokenResponseDTO = (token, expiresIn) => {
     return {
-        accessToken: token,
-        accessTokenExpiresIn: expiresIn,
+        accessToken: access,
+        accessTokenExpiresIn: accessExpiresIn,
+        refreshToken: refresh,
+        refreshTokenExpiresIn: refreshExpiresIn,
     }
 }
 

--- a/src/providers/user.provider.js
+++ b/src/providers/user.provider.js
@@ -67,11 +67,29 @@ export const setUserKeyCache = async (key, kakaoId) => {
 /** redis 회원가입 key 조회 */
 export const getUserKeyCache = async (key) => {
     const kakaoId = await redisClient.get(key);
-    console.log('kakaoId: ', kakaoId);
     return kakaoId;
 }
 
 /** redis 회원가입 key 삭제 */
 export const deleteUserKeyCache = async (key) => {
+    await redisClient.del(key);
+}
+
+/** redis refreshToken 저장 */
+export const setRefreshTokenCache = async (userId, refreshToken) => {
+    const key = String(userId);
+    await redisClient.set(key, refreshToken, 'EX', 60 * 60 * 24 * 7); // 7일
+}
+
+/** redis refreshToken 조회 */
+export const getRefreshTokenCache = async (userId) => {
+    const key = String(userId);
+    const refreshToken = await redisClient.get(key);
+    return refreshToken;
+}
+
+/** redis refreshToken 삭제 */
+export const deleteRefreshTokenCache = async (userId) => {
+    const key = String(userId);
     await redisClient.del(key);
 }

--- a/src/providers/user.provider.js
+++ b/src/providers/user.provider.js
@@ -2,6 +2,7 @@ import axios from "axios";
 import CryptoJS from "crypto-js";
 import { status } from "@config/response.status";
 import { BaseError } from "@config/error";
+import { redisClient } from "@config/redis";
 
 /** 카카오 토큰 발급 */
 export const getKakaoToken = async (authCode) => {
@@ -52,7 +53,25 @@ export const getKakaoUserInfo = async (kakaoToken) => {
     }
 }
 
-export const generateKeyFromKakaoId = (kakaoId) => {
+/** 카카오id로 회원가입 key 생성 */
+export const generateKeyFromKakaoId = async (kakaoId) => {
     const hash = CryptoJS.SHA256(kakaoId).toString();
     return hash;
+}
+
+/** redis 회원가입 key 저장 */
+export const setUserKeyCache = async (key, kakaoId) => {
+    await redisClient.set(key, kakaoId, 'EX', 60 * 60 * 24); // 24시간 캐싱
+}
+
+/** redis 회원가입 key 조회 */
+export const getUserKeyCache = async (key) => {
+    const kakaoId = await redisClient.get(key);
+    console.log('kakaoId: ', kakaoId);
+    return kakaoId;
+}
+
+/** redis 회원가입 key 삭제 */
+export const deleteUserKeyCache = async (key) => {
+    await redisClient.del(key);
 }

--- a/src/routes/user.route.js
+++ b/src/routes/user.route.js
@@ -1,6 +1,10 @@
 import express from 'express';
 import asyncHandler from 'express-async-handler';
+<<<<<<< HEAD
 import { getUserCnt, patchUserInfoCnt } from '@controllers/user.controller.js';
+=======
+import { getUserCnt, refreshTokenCnt } from '@controllers/user.controller.js';
+>>>>>>> 55e1f6d ([#41] Feat: 토큰 재발급 구현)
 
 export const userRouter = express.Router();
 

--- a/src/routes/user.route.js
+++ b/src/routes/user.route.js
@@ -1,10 +1,6 @@
 import express from 'express';
 import asyncHandler from 'express-async-handler';
-<<<<<<< HEAD
 import { getUserCnt, patchUserInfoCnt } from '@controllers/user.controller.js';
-=======
-import { getUserCnt, refreshTokenCnt } from '@controllers/user.controller.js';
->>>>>>> 55e1f6d ([#41] Feat: 토큰 재발급 구현)
 
 export const userRouter = express.Router();
 

--- a/src/services/user.service.js
+++ b/src/services/user.service.js
@@ -9,7 +9,7 @@ import { generateKeyFromKakaoId } from "@providers/user.provider";
 export const addUserSer = async (body) => {
     let kakaoId = await getUserKeyCache(body.key);
     let joinUserId;
-    console.log('kakaoId: ', kakaoId);
+
     if (kakaoId) {
         await deleteUserKeyCache(body.key);
 
@@ -79,7 +79,10 @@ export const getUserSer = async (userId) => {
 
 /** 토큰 생성 */
 export const generateToken = async (payload) => {
-    const token = jwt.sign(payload, process.env.JWT_SECRET, { expiresIn: '1h' });
-    const expiresIn = new Date(Date.now() + 60 * 60 * 1000);
-    return userTokenResponseDTO(token, expiresIn);
+    const access = jwt.sign(payload, process.env.JWT_SECRET, { expiresIn: '1h' });
+    const refresh = jwt.sign(payload, process.env.JWT_SECRET, { expiresIn: '7d' });
+    const accessExpiresIn = new Date(Date.now() + 60 * 60 * 1000);
+    const refreshExpiresIn = new Date(Date.now() + 7 * 24 * 60 * 60 * 1000);
+    
+    return userTokenResponseDTO(access, accessExpiresIn, refresh, refreshExpiresIn);
 }

--- a/src/services/user.service.js
+++ b/src/services/user.service.js
@@ -7,16 +7,14 @@ import { generateKeyFromKakaoId } from "@providers/user.provider";
 
 /** 사용자 회원가입 서비스 */
 export const addUserSer = async (body) => {
-    let kakaoId;
+    let kakaoId = await getUserKeyCache(body.key);
     let joinUserId;
-
-    if (userKeyCache.has(body.key)) {
-        kakaoId = userKeyCache.get(body.key);
-        userKeyCache.delete(body.key); // 캐싱된 key 삭제
+    console.log('kakaoId: ', kakaoId);
+    if (kakaoId) {
+        await deleteUserKeyCache(body.key);
 
         // id 리턴
         joinUserId = await addUserDao({
-            "key": body.key,
             "kakaoId": kakaoId,
             "nickname": body.nickname,
         });
@@ -53,8 +51,8 @@ export const getUserByKakaoId = async (kakaoId) => {
     const result = await getUserByKakaoIdDao(kakaoId);
 
     if (result === undefined) { // 신규 유저
-        const key = generateKeyFromKakaoId(kakaoId);
-        userKeyCache.set(key, kakaoId); // 카카오 id - key값 캐싱
+        const key = await generateKeyFromKakaoId(kakaoId);
+        await setUserKeyCache(key, kakaoId);
         return {
             "isExists": false,
             "key": key,

--- a/src/services/user.service.js
+++ b/src/services/user.service.js
@@ -1,7 +1,7 @@
 import jwt from 'jsonwebtoken';
 import { status } from "@config/response.status";
 import { BaseError } from "@config/error";
-import { userTokenResponseDTO, userResponseDTO, userUpdateDTO, checkNicknameDTO } from '@dtos/user.dto.js';
+import { userTokenResponseDTO, userResponseDTO, userUpdateDTO, checkNicknameDTO, userAccessTokenResponseDTO } from '@dtos/user.dto.js';
 import { addUserDao, getUserDao, checkNicknameDao, getUserByKakaoIdDao, patchUserInfoDao } from '@models/user.dao.js';
 import { deleteUserKeyCache, generateKeyFromKakaoId, getUserKeyCache, setUserKeyCache } from "@providers/user.provider";
 
@@ -84,4 +84,10 @@ export const generateToken = async (payload) => {
     const refresh = jwt.sign(payload, process.env.JWT_SECRET, { expiresIn: '7d' });
     const refreshExpiresIn = new Date(Date.now() + 7 * 24 * 60 * 60 * 1000);
     return userTokenResponseDTO(access, accessExpiresIn, refresh, refreshExpiresIn);
+}
+
+export const generateAccessToken = async (payload) => {
+    const access = jwt.sign(payload, process.env.JWT_SECRET, { expiresIn: '1h' });
+    const accessExpiresIn = new Date(Date.now() + 60 * 60 * 1000);
+    return userAccessTokenResponseDTO(access, accessExpiresIn);
 }

--- a/src/services/user.service.js
+++ b/src/services/user.service.js
@@ -3,13 +3,13 @@ import { status } from "@config/response.status";
 import { BaseError } from "@config/error";
 import { userTokenResponseDTO, userResponseDTO, userUpdateDTO, checkNicknameDTO } from '@dtos/user.dto.js';
 import { addUserDao, getUserDao, checkNicknameDao, getUserByKakaoIdDao, patchUserInfoDao } from '@models/user.dao.js';
-import { generateKeyFromKakaoId } from "@providers/user.provider";
+import { deleteUserKeyCache, generateKeyFromKakaoId, getUserKeyCache, setUserKeyCache } from "@providers/user.provider";
 
 /** 사용자 회원가입 서비스 */
 export const addUserSer = async (body) => {
     let kakaoId = await getUserKeyCache(body.key);
     let joinUserId;
-
+    console.log('kakaoId: ', kakaoId);
     if (kakaoId) {
         await deleteUserKeyCache(body.key);
 
@@ -80,9 +80,8 @@ export const getUserSer = async (userId) => {
 /** 토큰 생성 */
 export const generateToken = async (payload) => {
     const access = jwt.sign(payload, process.env.JWT_SECRET, { expiresIn: '1h' });
-    const refresh = jwt.sign(payload, process.env.JWT_SECRET, { expiresIn: '7d' });
     const accessExpiresIn = new Date(Date.now() + 60 * 60 * 1000);
+    const refresh = jwt.sign(payload, process.env.JWT_SECRET, { expiresIn: '7d' });
     const refreshExpiresIn = new Date(Date.now() + 7 * 24 * 60 * 60 * 1000);
-    
     return userTokenResponseDTO(access, accessExpiresIn, refresh, refreshExpiresIn);
 }

--- a/src/utils/jwt.util.js
+++ b/src/utils/jwt.util.js
@@ -1,0 +1,29 @@
+import { BaseError } from '@config/error';
+import { status } from '@config/response.status';
+import { deleteRefreshTokenCache, getRefreshTokenCache, setRefreshTokenCache } from '@providers/user.provider';
+import { generateToken } from '@services/user.service';
+import jwt from 'jsonwebtoken';
+
+export const refresh = async (refreshToken) => {
+    try {
+        const decoded = jwt.verify(refreshToken, process.env.JWT_SECRET);
+        const cachedRefreshToken = await getRefreshTokenCache(decoded.userId);
+
+        if (refreshToken !== cachedRefreshToken) {
+            throw new BaseError(status.TOKEN_INVALID)
+        }
+
+        await deleteRefreshTokenCache(decoded.userId);
+
+        const payload = {
+            userId: decoded.userId,
+            nickname: decoded.nickname,
+            kakaoId: decoded.kakaoId,
+        };
+        const tokenResponse = await generateToken(payload);
+        await setRefreshTokenCache(decoded.userId, tokenResponse.refreshToken);
+        return tokenResponse;
+    } catch (error) {
+        throw new BaseError(status.UNAUTHORIZED);
+    }
+}

--- a/src/utils/jwt.util.js
+++ b/src/utils/jwt.util.js
@@ -1,7 +1,7 @@
 import { BaseError } from '@config/error';
 import { status } from '@config/response.status';
 import { deleteRefreshTokenCache, getRefreshTokenCache, setRefreshTokenCache } from '@providers/user.provider';
-import { generateToken } from '@services/user.service';
+import { generateAccessToken, generateToken } from '@services/user.service';
 import jwt from 'jsonwebtoken';
 
 export const refresh = async (refreshToken) => {
@@ -13,15 +13,12 @@ export const refresh = async (refreshToken) => {
             throw new BaseError(status.TOKEN_INVALID)
         }
 
-        await deleteRefreshTokenCache(decoded.userId);
-
         const payload = {
             userId: decoded.userId,
             nickname: decoded.nickname,
             kakaoId: decoded.kakaoId,
         };
-        const tokenResponse = await generateToken(payload);
-        await setRefreshTokenCache(decoded.userId, tokenResponse.refreshToken);
+        const tokenResponse = await generateAccessToken(payload);
         return tokenResponse;
     } catch (error) {
         throw new BaseError(status.UNAUTHORIZED);

--- a/swagger/user.swagger.yml
+++ b/swagger/user.swagger.yml
@@ -33,6 +33,7 @@ paths:
                 type: boolean
                 example: true
               code:
+                type: string
                 example: 2000
               message:
                 type: string
@@ -121,7 +122,7 @@ paths:
                 type: boolean
                 example: true
               code:
-                type: integer
+                type: string
                 example: 2000
               message:
                 type: string
@@ -178,7 +179,7 @@ paths:
                 type: string
               key:
                 type: string
-                example: 4ea...
+                example: 4ea5c508a6566e76240543f8feb06fd457777be39549c4016436afda65d2330e
       responses:
         "200":
           description: 사용자 회원가입 성공
@@ -189,6 +190,7 @@ paths:
                 type: boolean
                 example: true
               code:
+                type: string
                 example: 2000
               message:
                 type: string
@@ -261,6 +263,7 @@ paths:
                 type: boolean
                 example: true
               code:
+                type: string
                 example: 2000
               message:
                 type: string
@@ -332,6 +335,7 @@ paths:
                 type: boolean
                 example: true
               code:
+                type: string
                 example: 2000
               message:
                 type: string
@@ -401,6 +405,7 @@ paths:
                 type: boolean
                 example: true
               code:
+                type: string
                 example: 2000
               message:
                 type: string
@@ -436,6 +441,7 @@ paths:
                 type: boolean
                 example: true
               code:
+                type: string
                 example: 2000
               message:
                 type: string

--- a/swagger/user.swagger.yml
+++ b/swagger/user.swagger.yml
@@ -48,26 +48,15 @@ paths:
                     example: eyJ...
                   accessTokenExpires:
                     type: string
-                    example: 2024-08-01T04:32:22Z
-          examples:
-            application/json:
-              기존 유저:
-                isSuccess: true
-                code: 2000
-                message: success!
-                result:
-                  isExist: true
-                  accessToken: eyJ...
-                  accessTokenExpires: 2024-08-01T04:32:22Z
-              신규 유저:
-                isSuccess: true
-                code: 2000
-                message: success!
-                result:
-                  isExist: false
-                  key: 4ea...
-        "400":
-          description: 서버 JWT 발급 실패
+                    example: 2024-08-21T08:35:03.183Z
+                  refreshToken:
+                    type: string
+                    example: eyJ...
+                  refreshTokenExpires:
+                    type: string
+                    example: 2024-08-28T07:35:03.183Z
+        "404":
+          description: 소셜 로그인 실패
           schema:
             type: object
             properties:
@@ -212,7 +201,13 @@ paths:
                     example: eyJ...
                   accessTokenExpires:
                     type: string
-                    example: 2024-08-01T04:32:22Z
+                    example: 2024-08-21T08:35:03.183Z
+                  refreshToken:
+                    type: string
+                    example: eyJ...
+                  refreshTokenExpires:
+                    type: string
+                    example: 2024-08-28T07:35:03.183Z
         "400":
           description: 잘못된 요청
           schema:
@@ -380,6 +375,51 @@ paths:
               message:
                 type: string
                 example: 서버 에러, 관리자에게 문의 바랍니다.
+  /user/refresh:
+    post:
+      tags:
+        - User
+      summary: 토큰 재발급
+      description: 사용자 토큰 재발급을 위한 API 입니다. body에 refreshToken을 보내주세요.
+      parameters:
+        - in: body
+          name: body
+          description: refreshToken
+          required: true
+          schema:
+            type: object
+            properties:
+              refreshToken:
+                type: string
+      responses:
+        "200":
+          description: 토큰 재발급 성공
+          schema:
+            type: object
+            properties:
+              isSuccess:
+                type: boolean
+                example: true
+              code:
+                example: 2000
+              message:
+                type: string
+                example: success!
+              result:
+                type: object
+                properties:
+                  accessToken:
+                    type: string
+                    example: eyJ...
+                  accessTokenExpires:
+                    type: string
+                    example: 2024-08-21T08:35:03.183Z
+                  refreshToken:
+                    type: string
+                    example: eyJ...
+                  refreshTokenExpires:
+                    type: string
+                    example: 2024-08-28T07:35:03.183Z
   /user/token/test:
     post:
       tags:
@@ -406,6 +446,15 @@ paths:
                   accessToken:
                     type: string
                     example: eyJ...
+                  accessTokenExpires:
+                    type: string
+                    example: 2024-08-21T08:35:03.183Z
+                  refreshToken:
+                    type: string
+                    example: eyJ...
+                  refreshTokenExpires:
+                    type: string
+                    example: 2024-08-28T07:35:03.183Z
         "400":
           description: 토큰 발급 실패
           schema:

--- a/swagger/user.swagger.yml
+++ b/swagger/user.swagger.yml
@@ -419,12 +419,6 @@ paths:
                   accessTokenExpires:
                     type: string
                     example: 2024-08-21T08:35:03.183Z
-                  refreshToken:
-                    type: string
-                    example: eyJ...
-                  refreshTokenExpires:
-                    type: string
-                    example: 2024-08-28T07:35:03.183Z
   /user/token/test:
     post:
       tags:


### PR DESCRIPTION
## 관련 이슈

- #41

## 요약 📝

- redis 환경을 구현하고, 회원가입 key, refresh token을 관리합니다.

## 상세 내용 🔥

- redis 환경 구현
  - ec2 elasticache 클러스터를 생성해, 배포 서버에서 redis 접속이 가능합니다.
  - 로컬에서는 회원가입 ~ 토큰 재발급까지 문제 없었으나, 배포 후에는 안될 듯한 이 느낌은 뭘까요..
- 토큰 재발급 구현
  - refresh token을 구현하였습니다. 유효기간은 7일!
  - 토큰 재발급 api를 구현하였습니다. body로 refresh token을 받아, jwt를 재발급 받습니다.
  - 유효기간이 지난 access token에 대하여 토큰 만료 에러를 추가하였습니다.
  - 로그인/회원가입 성공 시 다음의 형태로 내려갑니다.
```json
{
  "isSuccess": true,
  "code": "2000",
  "message": "success!",
  "result": {
    "accessToken": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VySWQiOjE0NSwibmlja25hbWUiOiJzdHJpbmciLCJrYWthb0lkIjozNjQ2Mzk1ODYwLCJpYXQiOjE3MjQyMzY0NjMsImV4cCI6MTcyNDI0MDA2M30.Vb9qm12lbcdSegEySIOeNCxezANAdp3A6aaq513q8jg",
    "accessTokenExpiresIn": "2024-08-21T11:34:23.014Z",
    "refreshToken": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VySWQiOjE0NSwibmlja25hbWUiOiJzdHJpbmciLCJrYWthb0lkIjozNjQ2Mzk1ODYwLCJpYXQiOjE3MjQyMzY0NjMsImV4cCI6MTcyNDg0MTI2M30.cy4v_mPUysK8gkNR19UVD96W2G5XvAxeDElKH8bHcNg",
    "refreshTokenExpiresIn": "2024-08-28T10:34:23.016Z"
  }
}
```
- 회원가입 key를 redis에서 관리
  - 로그인시 getUserByKakaoId 에서 신규 유저 분기처리를 할 때, key를 생성하고 redis에 {key}-{kakaoId} 형태로 저장합니다.
  - 회원가입 시 body에 담긴 key로 redis에서 검색하여, 유효성 검사 및 회원가입을 실시합니다.
- refresh token도 redis에서 관리
  - 로그인/회원가입 시 refresh token을 {userId}-{refreshToken} 형태로 redis에 저장합니다.
  - 이후, 재발급 요청이 들어오면 body로 받은 refresh token과, 토큰에서 추출한 userId로 redis에서 검색한 token값이 일치하는지 검증합니다.
  - 동일할 시, 토큰을 발급합니다. 재발급 형식은 위와 동일합니다.

## 리뷰어에게 부탁, 유의사항 🙏

- 로컬에서 레디스 테스트 필요시, 로컬에서 레디스 설치 후 서버를 열어야 테스트 가능합니다.
- elasticache 인바운드 설정에 제한을 걸어서 배포된 서버에서만 접속 가능합니다. 로컬 환경에서는 elasticache의 레디스 서버에 접속할 수 없고, 로컬에서 레디스를 연 뒤 환경변수의 REDIS_URL을 redis://localhost:6379 로 설정해 접속해야합니다.